### PR TITLE
Remove whitespace in Comfy-Mono color scheme name

### DIFF
--- a/Comfy-Mono/color.ini
+++ b/Comfy-Mono/color.ini
@@ -1,4 +1,4 @@
-[Comfy Shadow]
+[Comfy]
 text               = FFFFFF
 subtext            = B9BBBE
 main               = 171717


### PR DESCRIPTION
Spicetify color schemes cannot contain whitespace. As such, I changed the name from `Comfy Shadow` to `Comfy`. The same name as the regular Comfy theme also reduces excess configuration when swapping between the two themes, as only the theme itself will need to be changed rather than the theme and the color scheme.