### PR TITLE
feat(extension): preload album images

### DIFF
--- a/Comfy-Chromatic/Comfy-Chromatic.script.js
+++ b/Comfy-Chromatic/Comfy-Chromatic.script.js
@@ -1,5 +1,6 @@
 (function Comfy() {
     const { Player, Menu, LocalStorage, Platform } = Spicetify
+    const preloadChild = document.createElement("div")
 	const mainChild = document.createElement("div")
     const main = document.querySelector('.Root__main-view')
     const LyricsBackground = document.querySelector('.lyrics-lyricsContainer-LyricsBackground')
@@ -38,9 +39,16 @@
     main.appendChild(mainChild)
     mainChild.id = "mainImage"
 
+    main.appendChild(preloadChild)
+    preloadChild.id = "preloadImage"
+
     for (var i = 0; i < channels.length; i++) {
         if (Platform.History.location.pathname.startsWith(channels[i])) {
-            mainChild.style.backgroundImage = "url(" + Player.data.track.metadata.image_xlarge_url + ")"
+            preloadChild.style.content = "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+            setInterval(() => {
+                mainChild.style.backgroundImage =
+                "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+            }, 1000);
         }
     }
 
@@ -51,7 +59,11 @@
         for (var i = 0; i < channels.length; i++) {
 
             if (pathname.startsWith(channels[i])) {
-                mainChild.style.backgroundImage = "url(" + Player.data.track.metadata.image_xlarge_url + ")"
+                preloadChild.style.content = "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                setInterval(() => {
+                    mainChild.style.backgroundImage =
+                    "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                }, 1000);
                 return
             }
 
@@ -65,7 +77,11 @@
     Player.addEventListener("songchange", () => {
         for (var i = 0; i < channels.length; i++) {
             if (Platform.History.location.pathname.startsWith(channels[i])) {
-                mainChild.style.backgroundImage = "url(" + Player.data.track.metadata.image_xlarge_url + ")"
+                preloadChild.style.content = "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                setInterval(() => {
+                    mainChild.style.backgroundImage =
+                    "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                }, 1000);
             }
         }
     })

--- a/Comfy-Mono/Comfy-Mono.script.js
+++ b/Comfy-Mono/Comfy-Mono.script.js
@@ -1,5 +1,6 @@
 (function Comfy() {
     const { Player, Menu, LocalStorage, Platform } = Spicetify
+    const preloadChild = document.createElement("div")
 	const mainChild = document.createElement("div")
     const main = document.querySelector('.Root__main-view')
     const LyricsBackground = document.querySelector('.lyrics-lyricsContainer-LyricsBackground')
@@ -38,9 +39,16 @@
     main.appendChild(mainChild)
     mainChild.id = "mainImage"
 
+    main.appendChild(preloadChild)
+    mainChild.id = "preloadImage"
+
     for (var i = 0; i < channels.length; i++) {
         if (Platform.History.location.pathname.startsWith(channels[i])) {
-            mainChild.style.backgroundImage = "url(" + Player.data.track.metadata.image_xlarge_url + ")"
+            preloadChild.style.content = "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+            setInterval(() => {
+                mainChild.style.backgroundImage =
+                "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+            }, 1000);
         }
     }
 
@@ -51,7 +59,11 @@
         for (var i = 0; i < channels.length; i++) {
 
             if (pathname.startsWith(channels[i])) {
-                mainChild.style.backgroundImage = "url(" + Player.data.track.metadata.image_xlarge_url + ")"
+                preloadChild.style.content = "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                setInterval(() => {
+                    mainChild.style.backgroundImage =
+                    "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                }, 1000);
                 return
             }
 
@@ -65,7 +77,11 @@
     Player.addEventListener("songchange", () => {
         for (var i = 0; i < channels.length; i++) {
             if (Platform.History.location.pathname.startsWith(channels[i])) {
-                mainChild.style.backgroundImage = "url(" + Player.data.track.metadata.image_xlarge_url + ")"
+                preloadChild.style.content = "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                setInterval(() => {
+                    mainChild.style.backgroundImage =
+                    "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                }, 1000);
             }
         }
     })

--- a/Comfy/Comfy.script.js
+++ b/Comfy/Comfy.script.js
@@ -3,6 +3,7 @@
     const main = document.querySelector('.Root__main-view')
     const LyricsBackground = document.querySelector('.lyrics-lyricsContainer-LyricsBackground')
     const mainChild = document.createElement("div")
+    const preloadChild = document.createElement("div")
 
     if (!(Player && Menu && LocalStorage && Platform && main)) {
         setTimeout(Comfy, 1000)
@@ -13,10 +14,17 @@
     main.appendChild(mainChild)
     mainChild.id = "mainImage"
 
+    main.appendChild(preloadChild)
+    preloadChild.id = "preloadImage"
+
     // Spotify launching on a playlist
     for (var i = 0; i < channels.length; i++) {
         if (Platform.History.location.pathname.startsWith(channels[i])) {
-            mainChild.style.backgroundImage = "url(" + Player.data.track.metadata.image_xlarge_url + ")"
+            preloadChild.style.content = "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+            setInterval(() => {
+                mainChild.style.backgroundImage =
+                "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+            }, 1000);
         }
     }
 
@@ -27,7 +35,11 @@
         for (var i = 0; i < channels.length; i++) {
 
             if (pathname.startsWith(channels[i])) {
-                mainChild.style.backgroundImage = "url(" + Player.data.track.metadata.image_xlarge_url + ")"
+                preloadChild.style.content = "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                setInterval(() => {
+                    mainChild.style.backgroundImage =
+                    "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                }, 1000);
                 return
             }
 
@@ -39,7 +51,11 @@
     Player.addEventListener("songchange", () => {
         for (var i = 0; i < channels.length; i++) {
             if (Platform.History.location.pathname.startsWith(channels[i])) {
-                mainChild.style.backgroundImage = "url(" + Player.data.track.metadata.image_xlarge_url + ")"
+                preloadChild.style.content = "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                setInterval(() => {
+                    mainChild.style.backgroundImage =
+                    "url(" + Player.data.track.metadata.image_xlarge_url + ")";
+                }, 1000);
             }
         }
     })

--- a/Comfy/app.css
+++ b/Comfy/app.css
@@ -1,3 +1,10 @@
+:root .Root__main-view #preloadImage {
+  position:absolute;
+  width:0;
+  height:0;
+  overflow:hidden;
+  z-index:-1;
+}
 :root .Root__main-view #mainImage {
   position: absolute;
   width: 100%;

--- a/Comfy/assets/_main.scss
+++ b/Comfy/assets/_main.scss
@@ -1,4 +1,12 @@
 :root .Root__main-view {
+    #preloadImage {
+        position:absolute;
+        width:0;
+        height:0;
+        overflow:hidden;
+        z-index:-1;
+    }
+
     #mainImage {
         position: absolute; // instead of background-attachment
         width: 100%;
@@ -51,32 +59,32 @@
     }
 
     .main-yourEpisodes-yourEpisodesContentWrapper { max-width: unset;}
-    .main-actionBarBackground-background { 
-        background: linear-gradient(rgba(var(--spice-rgb-shadow),.6) 0, var(--spice-main) 232px), var(--background-noise) !important; 
+    .main-actionBarBackground-background {
+        background: linear-gradient(rgba(var(--spice-rgb-shadow),.6) 0, var(--spice-main) 232px), var(--background-noise) !important;
         height: calc(100% - 243px);
     }
 
     // Playlist, Album & Liked songs
-    section { 
+    section {
         &[data-testid="playlist-page"] .main-actionBar-ActionBar, &[data-testid="album-page"] .main-actionBar-ActionBar, &[data-testid="your-episodes-page"] .main-actionBar-ActionBar, &[data-testid="artist-page"] .main-actionBar-ActionBar {
             padding: 8px 16px 16px 16px;
-    
+
             .main-playButton-PlayButton {
                 margin-top: -24px; margin-left: 8px;
                 margin-right: 22px;
             }
-    
+
             @media (min-width: 1024px) { .main-playButton-PlayButton { margin-left: 24px;}}
         }
 
         &[data-testid="your-episodes-page"] > .contentSpacing > section { height: calc(100vh - 494px);}
-        &[data-testid="your-episodes-page"] > .main-yourEpisodes-yourEpisodesContentWrapper { 
+        &[data-testid="your-episodes-page"] > .main-yourEpisodes-yourEpisodesContentWrapper {
             height: calc(100vh - 438px);
 
             [data-testid^="episode-"] { margin: 0;}
         }
-        
-        &[data-testid="playlist-page"] > div:last-child, &[data-testid="album-page"] > div:nth-last-child(2), 
+
+        &[data-testid="playlist-page"] > div:last-child, &[data-testid="album-page"] > div:nth-last-child(2),
         &[data-testid="episode"] > div:last-child, &[data-testid="your-episodes-page"] > div:last-child, &[data-testid="artist-page"] > div > div:last-child {
             background: none;
 
@@ -91,7 +99,7 @@
             }
             .main-trackList-trackListHeader { display: none;}
         }
-        
+
         // Album & Liked songs
         &[data-testid] { position: relative;}
     }


### PR DESCRIPTION
This PR enables a smooth-_ish_ transition when switching songs as opposed to the current method by loading the image inside a non-visible div and then load the image onto the chosen div after a period of time (currently using `1000` ms)

This proposed method isn't fool-proof as it can't detect whether the image has completely finished loading, and the experience won't be much different of those with slow Internet connection (not finished loading images significantly after 1s), but it will bring a smooth (or at least smoother) experience for the general users with decent Internet connection (completes loading images in under/near 1s)

The duration can be altered if needed.

<details>
<summary>Example</summary>

- Current
![Spotify_Ai5KUiXWSi](https://user-images.githubusercontent.com/77577746/170876805-85397f8d-111e-4724-a3ed-7d0c51841198.gif)

- Proposed changes
![Spotify_TPTFihp1Pn](https://user-images.githubusercontent.com/77577746/170876816-47846ab8-d731-49cd-ba3a-6f93891ca7d1.gif)

</details>