### PR TITLE
improvements to hoverable panels

### DIFF
--- a/Comfy-Chromatic/user.css
+++ b/Comfy-Chromatic/user.css
@@ -2,6 +2,6 @@
 
 /*/ ENABLE THIS LINE FOR HOVERED PANELS
 
-.Root__nav-bar {position: absolute;width: 40px;opacity: 0;bottom: 0;left: 0;top: 0;z-index: 1;}nav.Root__nav-bar:hover {position: inherit;width: 225px;opacity: 1;transition: visibility 5s, opacity 0.5s linear;}.LayoutResizer__resize-bar {cursor: none;}.Root__top-bar {opacity: 0;transition: visibility 5s, opacity 1s linear;}.Root__top-bar:hover {transition-delay: 0.5s;opacity: 1;transition: visibility 5s, opacity 0.5s linear;}.main-topBar-container {-webkit-padding-end: 32px;padding: 16px 85px;padding-inline-end: 32px;max-width: none;}aside[aria-label='Friend Activity']:hover {position: inherit;width: var(--buddy-feed-width);opacity: 1;transition: visibility 5s, opacity 0.5s linear;left: 0;}aside[aria-label='Friend Activity'] {position: absolute;width: 65px;opacity: 0;bottom: 0;left: -30px;top: 0;z-index: 1;}
+@import url("https://comfy-themes.github.io/Spicetify/hovered.css")
 
 ENABLE THIS LINE FOR HOVERED PANELS /*/

--- a/Comfy-Mono/user.css
+++ b/Comfy-Mono/user.css
@@ -2,6 +2,6 @@
 
 /*/ ENABLE THIS LINE FOR HOVERED PANELS
 
-.Root__nav-bar {position: absolute;width: 40px;opacity: 0;bottom: 0;left: 0;top: 0;z-index: 1;}nav.Root__nav-bar:hover {position: inherit;width: 225px;opacity: 1;transition: visibility 5s, opacity 0.5s linear;}.LayoutResizer__resize-bar {cursor: none;}.Root__top-bar {opacity: 0;transition: visibility 5s, opacity 1s linear;}.Root__top-bar:hover {transition-delay: 0.5s;opacity: 1;transition: visibility 5s, opacity 0.5s linear;}.main-topBar-container {-webkit-padding-end: 32px;padding: 16px 85px;padding-inline-end: 32px;max-width: none;}aside[aria-label='Friend Activity']:hover {position: inherit;width: var(--buddy-feed-width);opacity: 1;transition: visibility 5s, opacity 0.5s linear;left: 0;}aside[aria-label='Friend Activity'] {position: absolute;width: 65px;opacity: 0;bottom: 0;left: -30px;top: 0;z-index: 1;}
+@import url("https://comfy-themes.github.io/Spicetify/hovered.css")
 
 ENABLE THIS LINE FOR HOVERED PANELS /*/

--- a/Comfy/user.css
+++ b/Comfy/user.css
@@ -2,6 +2,6 @@
 
 /*/ ENABLE THIS LINE FOR HOVERED PANELS
 
-.Root__nav-bar {position: absolute;width: 40px;opacity: 0;bottom: 0;left: 0;top: 0;z-index: 1;}nav.Root__nav-bar:hover {position: inherit;width: 225px;opacity: 1;transition: visibility 5s, opacity 0.5s linear;}.LayoutResizer__resize-bar {cursor: none;}.Root__top-bar {opacity: 0;transition: visibility 5s, opacity 1s linear;}.Root__top-bar:hover {transition-delay: 0.5s;opacity: 1;transition: visibility 5s, opacity 0.5s linear;}.main-topBar-container {-webkit-padding-end: 32px;padding: 16px 85px;padding-inline-end: 32px;max-width: none;}aside[aria-label='Friend Activity']:hover {position: inherit;width: var(--buddy-feed-width);opacity: 1;transition: visibility 5s, opacity 0.5s linear;left: 0;}aside[aria-label='Friend Activity'] {position: absolute;width: 65px;opacity: 0;bottom: 0;left: -30px;top: 0;z-index: 1;}
+@import url("https://comfy-themes.github.io/Spicetify/hovered.css")
 
 ENABLE THIS LINE FOR HOVERED PANELS /*/

--- a/hovered.css
+++ b/hovered.css
@@ -1,0 +1,61 @@
+.Root__nav-bar {
+	position: absolute;
+	width: 40px;
+	opacity: 0;
+	bottom: 0;
+	left: 0;
+	top: 0;
+	z-index: 1;
+	transition: opacity 0.25s linear, width 0.3s;
+	transition-delay: 0.25s;
+}
+
+nav.Root__nav-bar:hover {
+	position: absolute;
+	width: 225px;
+	opacity: 1;
+	transition-delay: 0s;
+}
+
+.LayoutResizer__resize-bar {
+	cursor: none;
+}
+
+.Root__top-bar {
+	opacity: 0;
+	transition: opacity 0.5s linear;
+	transition-delay: 0.25s;
+}
+
+.Root__top-bar:hover {
+	opacity: 1;
+	transition: opacity 0.25s linear;
+	transition-delay: 0s;
+}
+
+.main-topBar-container {
+	-webkit-padding-end: 32px;
+	padding: 16px 85px;
+	padding-inline-end: 32px;
+	max-width: none;
+}
+
+aside[aria-label='Friend Activity']:hover {
+	position: absolute;
+	width: var(--buddy-feed-width);
+	opacity: 1;
+	left: calc(var(--buddy-feed-width) * -1);
+	transition-delay: 0s;
+}
+
+aside[aria-label='Friend Activity'] {
+	position: absolute;
+	width: 65px;
+	opacity: 0;
+	bottom: 0;
+	left: -30px;
+	top: 0;
+	z-index: 1;
+	transition: opacity 0.25s linear, width 0.3s, left 0.3s;
+	transition-delay: 0.25s;
+}


### PR DESCRIPTION
Improved the hoverable panels, making them less jarring to open and close. The main change is that they no longer resize the main window when opening and closing. 
They now transition in and out, and all transitions are consistent between the three transitioning things.

Also moved the hoverable panels into a separate file (in main directory) so they could be maintained easier and referenced in a main file for consistency.