### PR TITLE
feat(Marketplace): compatibility with new version

### DIFF
--- a/Comfy-Chromatic/app.css
+++ b/Comfy-Chromatic/app.css
@@ -396,133 +396,141 @@ background-color: var(--spice-subtext) !important;
   height: 60px;
 }
 :root .Root__main-view #preloadImage {
-  position: absolute;
-  width: 0;
-  height: 0;
-  overflow: hidden;
-  z-index: -1;
+position: absolute;
+width: 0;
+height: 0;
+overflow: hidden;
+z-index: -1;
 }
 :root .Root__main-view #mainImage {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-  background-size: 100%;
-  background-repeat: no-repeat;
-  background-position: center;
-  will-change: transform;
-  z-index: -1;
-  transition: 300ms background-image ease-in-out;
-  filter: blur(4px);
-  -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
-  mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
+position: absolute;
+width: 100%;
+height: 100%;
+top: 0;
+left: 0;
+background-size: 100%;
+background-repeat: no-repeat;
+background-position: center;
+will-change: transform;
+z-index: -1;
+transition: 300ms background-image ease-in-out;
+filter: blur(4px);
+-webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
+mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
 }
 @media (max-width: 1500px) {
-  :root .Root__main-view #mainImage {
-    background-position: top;
-  }
+:root .Root__main-view #mainImage {
+  background-position: top;
+}
 }
 :root .Root__main-view .main-view-container__scroll-node-child {
-  padding-bottom: 0;
+padding-bottom: 0;
 }
 :root .Root__main-view .main-card-card {
-  border-radius: var(--border-radius);
-  padding: 0;
-  overflow: hidden;
+border-radius: var(--border-radius);
+padding: 0;
+overflow: hidden;
 }
 :root .Root__main-view .main-card-card .main-card-imageContainer {
-  margin-bottom: -4px;
+margin-bottom: -4px;
 }
 :root .Root__main-view .main-card-card .main-card-imageContainer .main-cardImage-circular, :root .Root__main-view .main-card-card .main-card-imageContainer img {
-  border-radius: 0;
+border-radius: 0;
 }
 :root .Root__main-view .main-card-card .main-card-cardMetadata {
-  padding: 16px;
+padding: 16px;
 }
 :root .Root__main-view .main-entityHeader-container .main-entityHeader-backgroundColor {
-  background: none !important;
+background: none !important;
 }
 :root .Root__main-view .main-entityHeader-container {
-  padding: 32px;
-  justify-content: center;
+padding: 32px;
+justify-content: center;
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) {
-  align-self: center;
+align-self: center;
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) + .main-entityHeader-headerText {
-  flex: unset;
-  justify-content: center;
+flex: unset;
+justify-content: center;
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) + .main-entityHeader-headerText .main-entityHeader-title h1 {
-  font-size: 50px !important;
+font-size: 50px !important;
 }
 :root .Root__main-view .main-yourEpisodes-yourEpisodesContentWrapper {
-  max-width: unset;
+max-width: unset;
 }
+#main > div > div.Root__top-container > div.Root__main-view > main > div.os-host.os-host-foreign.os-theme-spotify.os-host-resize-disabled.os-host-scrollbar-horizontal-hidden.main-view-container__scroll-node.os-host-transition.os-host-overflow.os-host-overflow-y > div.os-padding > div > div > div.main-view-container__scroll-node-child > section > div > div.iB16LxoPzDeVZo8zPhPQ > div.main-actionBarBackground-background {
+background: linear-gradient(rgba(255, 255, 255, 0.8) 0,
+var(--spice-main) 232px),
+var(--background-noise) !important;
+height: calc(100% - 243px);
+
+}
+
 :root .Root__main-view .main-actionBarBackground-background {
-  background: linear-gradient(rgba(var(--spice-rgb-shadow), 0.6) 0, var(--spice-main) 232px), var(--background-noise) !important;
-  height: calc(100% - 243px);
+background: linear-gradient(rgba(0, 0, 0, 0.6) 0,
+var(--spice-main) 232px),
+var(--background-noise) !important;
+height: calc(100% - 243px);
+
 }
-:root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar {
-  padding: 8px 16px 16px 16px;
-}
+
 :root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar .main-playButton-PlayButton {
-  margin-top: -24px;
-  margin-left: 8px;
-  margin-right: 22px;
+margin-top: -24px;
+margin-left: 8px;
+margin-right: 22px;
 }
 @media (min-width: 1024px) {
-  :root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar .main-playButton-PlayButton {
-    margin-left: 24px;
-  }
+:root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar .main-playButton-PlayButton {
+  margin-left: 24px;
+}
 }
 :root .Root__main-view section[data-testid=your-episodes-page] > .contentSpacing > section {
-  height: calc(100vh - 494px);
+height: calc(100vh - 494px);
 }
 :root .Root__main-view section[data-testid=your-episodes-page] > .main-yourEpisodes-yourEpisodesContentWrapper {
-  height: calc(100vh - 438px);
+height: calc(100vh - 438px);
 }
 :root .Root__main-view section[data-testid=your-episodes-page] > .main-yourEpisodes-yourEpisodesContentWrapper [data-testid^=episode-] {
-  margin: 0;
+margin: 0;
 }
-:root .Root__main-view section[data-testid=playlist-page] > div:last-child, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2), :root .Root__main-view section[data-testid=episode] > div:last-child, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child {
-  background: none;
+:root .Root__main-view section[data-testid=playlist-page] > div:last-child, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2), :root .Root__main-view section[data-testid=episode] > div:last-child, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child {
+background: none;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid {
-  border-radius: var(--border-radius);
-  border: none;
-  padding-left: 10px;
-  transition: 200ms background-color;
+border-radius: var(--border-radius);
+border: none;
+padding-left: 10px;
+transition: 200ms background-color;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid .main-type-mesto, :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid .main-type-ballad, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid .main-type-mesto, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid .main-type-ballad, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid .main-type-mesto, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid .main-type-ballad, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid .main-type-mesto, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid .main-type-ballad, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid .main-type-mesto, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid .main-type-ballad {
-  transition: 300ms color;
+transition: 300ms color;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid:hover {
-  background-color: rgba(255, 255, 255, 0.05);
+background-color: #3A3A3A40;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe {
-  background-color: rgba(255, 255, 255, 0.1);
+background-color: rgba(255, 255, 255, 0.1);
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListHeader, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListHeader, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListHeader, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListHeader, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListHeader {
-  display: none;
+display: none;
 }
 :root .Root__main-view section[data-testid] {
-  position: relative;
+position: relative;
 }
-:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackListRow {
-  grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [last] minmax(120px, 1fr) !important;
+
+:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex {
+position: absolute;
+z-index: 1000;
+top: 8px;
+left: 10px;
+width: 40px;
+height: 40px;
+justify-content: center;
+text-indent: -1000px;
 }
-:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex {
-  position: absolute;
-  z-index: 1000;
-  top: 8px;
-  left: 10px;
-  width: 40px;
-  height: 40px;
-  justify-content: center;
-  text-indent: -1000px;
-}
+
 .main-entityHeader-background.main-entityHeader-gradient {
   -webkit-animation: background-animation 1s linear;
   animation: background-animation 1s linear;
@@ -538,452 +546,459 @@ background-color: var(--spice-subtext) !important;
   -webkit-transform: scale(1.1);
   transform: scale(1.0);
 }
+
 :root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackList[aria-colcount="6"] .main-trackList-trackListRow, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackList[aria-colcount="6"] .main-trackList-trackListRow {
-  grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [var3] minmax(120px, 2fr) [last] minmax(120px, 1fr) !important;
+grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [var3] minmax(120px, 2fr) [last] minmax(120px, 1fr) !important;
 }
+
+
+
+:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow {
+  grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [last] minmax(120px, 1fr) !important;
+}
+
+
 
 :root .Root__nav-bar {
-  overflow: hidden;
+overflow: hidden;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints {
-  column-gap: 16px;
-  padding: 0 12px;
-  box-sizing: content-box;
-  transition: 350ms background-color;
-  border-radius: var(--border-radius) var(--border-radius) 0 0;
-  margin: 24px 12px 0 12px;
-  background-color: rgba(0, 0, 0, 0.1);
+-moz-column-gap: 16px;
+     column-gap: 16px;
+padding: 0 12px;
+box-sizing: content-box;
+transition: 350ms background-color;
+border-radius: var(--border-radius) var(--border-radius) 0 0;
+margin: 24px 12px 0 12px;
+background-color: rgba(0, 0, 0, 0.1);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list {
-  display: grid;
-  grid-template-areas: "home home home home" "search search search search" "collection collection collection collection" "lyrics-plus lyrics-plus lyrics-plus lyrics-plus" "reddit reddit reddit reddit" "new-releases new-releases new-releases new-releases" "marketplace marketplace marketplace marketplace" "add tracks episodes .";
-  grid-template-columns: 25px 25px 25px 1fr;
-  border-radius: var(--border-radius);
+display: grid;
+grid-template-areas: "home home home home" "search search search search" "collection collection collection collection" "lyrics-plus lyrics-plus lyrics-plus lyrics-plus" "reddit reddit reddit reddit" "new-releases new-releases new-releases new-releases" "marketplace marketplace marketplace marketplace" "add tracks episodes .";
+grid-template-columns: 25px 25px 25px 1fr;
+border-radius: var(--border-radius);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/"] {
-  grid-area: home;
+grid-area: home;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/search"] {
-  grid-area: search;
+grid-area: search;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/collection"] {
-  grid-area: collection;
+grid-area: collection;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/lyrics-plus"] {
-  grid-area: lyrics-plus;
+grid-area: lyrics-plus;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/reddit"] {
-  grid-area: reddit;
+grid-area: reddit;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/new-releases"] {
-  grid-area: new-releases;
+grid-area: new-releases;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id$=marketplace] {
-  grid-area: marketplace;
+:root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id$="marketplace"] {
+grid-area: marketplace;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list div[data-id="/add"] {
-  grid-area: add;
+grid-area: add;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list div[data-id="/collection/episodes"] {
-  grid-area: episodes;
+grid-area: episodes;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list div[data-id="/collection/tracks"] {
-  grid-area: tracks;
+grid-area: tracks;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li {
-  padding: 0;
-  margin: 0 -12px;
+padding: 0;
+margin: 0 -12px;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a {
-  padding: 0 12px;
-  border-radius: 0;
-  background-color: transparent;
+padding: 0 12px;
+border-radius: 0;
+background-color: transparent;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a.main-navBar-navBarLinkActive {
-  background-color: rgba(92, 110, 177, 0.1647058824);
+background-color: #5c6eb12a;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a svg > * {
-  display: none;
+display: none;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li:first-child a {
-  border-radius: var(--border-radius) var(--border-radius) 0 0;
+border-radius: var(--border-radius) var(--border-radius) 0 0;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div {
-  padding: 0;
-  margin: 2px 0;
+padding: 0;
+margin: 2px 0;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div > *.active {
-  background: none;
+background: none;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div button, :root .Root__nav-bar ul.main-navBar-entryPoints > div a {
-  padding: 0;
+padding: 0;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div button div, :root .Root__nav-bar ul.main-navBar-entryPoints > div a div {
-  margin-right: 0;
-  border-radius: var(--border-radius);
+margin-right: 0;
+border-radius: var(--border-radius);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div button div.main-rootlist-statusIcons, :root .Root__nav-bar ul.main-navBar-entryPoints > div a div.main-rootlist-statusIcons {
-  display: none;
+display: none;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div button span, :root .Root__nav-bar ul.main-navBar-entryPoints > div a span {
-  display: none;
+display: none;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/"] .home-icon {
-  background: url("https://i.imgur.com/jqDH9TQ.png") center/cover no-repeat;
+background: url("https://i.imgur.com/jqDH9TQ.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/"] .home-active-icon {
-  background: url("https://i.imgur.com/60h58oZ.png") center/cover no-repeat;
+background: url("https://i.imgur.com/60h58oZ.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/search"] .search-icon {
-  background: url("https://i.imgur.com/UV5JQpE.png") center/cover no-repeat;
+background: url("https://i.imgur.com/UV5JQpE.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/search"] .search-active-icon {
-  background: url("https://i.imgur.com/CTVdQ3d.png") center/cover no-repeat;
+background: url("https://i.imgur.com/CTVdQ3d.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/collection"] .collection-icon {
-  background: url("https://i.imgur.com/alXGfxW.png") center/cover no-repeat;
+background: url("https://i.imgur.com/alXGfxW.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/collection"] .collection-active-icon {
-  background: url("https://i.imgur.com/SzvrAfr.png") center/cover no-repeat;
+background: url("https://i.imgur.com/SzvrAfr.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/lyrics-plus"] .collection-icon {
-  background: url("https://i.imgur.com/91fuU3P.png") center/cover no-repeat;
+background: url("https://i.imgur.com/91fuU3P.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/lyrics-plus"] .collection-active-icon {
-  background: url("https://i.imgur.com/EgRCYe8.png") center/cover no-repeat;
+background: url("https://i.imgur.com/EgRCYe8.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/reddit"] .collection-icon {
-  background: url("https://i.imgur.com/6N6ev2V.png") center/cover no-repeat;
+background: url("https://i.imgur.com/6N6ev2V.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/reddit"] .collection-active-icon {
-  background: url("https://i.imgur.com/UENFDdo.png") center/cover no-repeat;
+background: url("https://i.imgur.com/UENFDdo.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/new-releases"] .collection-icon {
-  background: url("https://i.imgur.com/BgkCeDG.png") center/cover no-repeat;
+background: url("https://i.imgur.com/BgkCeDG.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/new-releases"] .collection-active-icon {
-  background: url("https://i.imgur.com/CTRVDwF.png") center/cover no-repeat;
+background: url("https://i.imgur.com/CTRVDwF.png") center/cover no-repeat;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints a[href$=marketplace] .collection-icon {
-  background: url("https://i.imgur.com/2pWNa48.png") center/cover no-repeat;
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints a[href$=marketplace] .collection-active-icon {
-  background: url("https://i.imgur.com/rKmXQ6V.png") center/cover no-repeat;
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div {
-  display: grid;
-  grid-template-areas: "add tracks episodes" "playlists playlists playlists";
-  grid-template-columns: 25px 25px 1fr;
-  grid-template-rows: 25px 1fr;
-  column-gap: 16px;
-  margin: 12px 12px 0 12px;
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child {
-  grid-area: add;
-  margin: -6px 0 0 12px;
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child::before {
-  content: "";
-  position: absolute;
-  width: calc(100% - 24px);
-  height: 40px;
-  margin: -6px 0 0 -12px;
-  background-color: rgba(0, 0, 0, 0.1);
-  border-radius: 0 0 var(--border-radius) var(--border-radius);
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child button {
-  padding: 0;
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child button .main-createPlaylistButton-createPlaylistIcon {
-  border-radius: var(--border-radius);
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(2) {
-  grid-area: tracks;
-  margin: -6px 0 0 12px;
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(2) a {
-  padding: 0;
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(2) a .main-likedSongsButton-likedSongsIcon {
-  border-radius: var(--border-radius);
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) {
-  grid-area: episodes;
-  margin: -6px 0 0 12px;
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) a {
-  padding: 0;
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) a .main-yourEpisodesButton-yourEpisodesIcon {
-  border-radius: var(--border-radius);
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) a .main-collectionLinkButton-collectionLinkText {
-  display: none;
-}
-:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:last-child {
-  grid-area: playlists;
-}
-:root .Root__nav-bar .main-rootlist-rootlistDividerContainer {
-  display: none;
-}
-:root .Root__nav-bar .main-rootlist-rootlist {
-  margin-top: 0;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content {
-  padding-top: 16px !important;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content::before {
-  content: "Playlists";
-  visibility: visible;
-  width: unset;
-  height: unset;
-  line-height: unset;
-  display: block;
-  font-size: 16px;
-  text-align: center;
-  font-weight: bold;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] {
-  margin: 12px;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"]:not(#spicetify-playlist-list) {
-  margin: 12px 0 0 0;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div {
-  contain: unset;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) {
-  background-color: rgba(0, 0, 0, 0.1);
-  border-radius: 8px;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem {
-  padding: 0;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink {
-  padding-top: 4px;
-  padding-bottom: 4px;
-  padding-left: calc(12px + var(--indentation) * var(--left-sidebar-item-indentation-width));
-  padding-right: var(--left-sidebar-padding-right);
-  box-sizing: content-box;
-  transition: 150ms background-color;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink + button {
-  border-radius: 0 !important;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink + div > button {
-  margin-left: 0;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover + * {
-  background-color: rgba(92, 110, 177, 0.1647058824);
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-statusIcons:not(:empty) {
-  margin-inline-start: 0;
-  padding: 4px 12px;
-  transition: 150ms background-color;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-expandArrow {
-  height: unset;
-  margin-left: 0;
-  padding: 4px 12px;
-  transition: 150ms background-color;
-}
-:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) li:last-child::after {
-  position: absolute;
-  content: "";
-  width: 100px;
-  height: 40px;
-}
-:root .Root__nav-bar .main-coverSlotExpanded-container .cover-art .cover-art-image {
-  border-radius: 0;
-}
-:root .Root__nav-bar .os-scrollbar {
-  top: 52px;
-  bottom: 38px;
-  border-top-right-radius: calc(var(--border-radius) + 5px);
-  border-bottom-right-radius: calc(var(--border-radius) + 5px);
-  overflow: hidden;
+:root .Root__nav-bar ul.main-navBar-entryPoints a[href$="marketplace"] .collection-icon {
+background: url("https://i.imgur.com/2pWNa48.png") center/cover no-repeat;
 }
 
+:root .Root__nav-bar ul.main-navBar-entryPoints a[href$="marketplace"] .collection-active-icon {
+background: url("https://i.imgur.com/rKmXQ6V.png") center/cover no-repeat;
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div {
+display: grid;
+grid-template-areas: "add tracks episodes" "playlists playlists playlists";
+grid-template-columns: 25px 25px 1fr;
+grid-template-rows: 25px 1fr;
+-moz-column-gap: 16px;
+     column-gap: 16px;
+margin: 12px 12px 0 12px;
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child {
+grid-area: add;
+margin: -6px 0 0 12px;
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child::before {
+content: "";
+position: absolute;
+width: calc(100% - 24px);
+height: 40px;
+margin: -6px 0 0 -12px;
+background-color: rgba(0, 0, 0, 0.1);
+border-radius: 0 0 var(--border-radius) var(--border-radius);
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child button {
+padding: 0;
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child button .main-createPlaylistButton-createPlaylistIcon {
+border-radius: var(--border-radius);
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(2) {
+grid-area: tracks;
+margin: -6px 0 0 12px;
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(2) a {
+padding: 0;
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(2) a .main-likedSongsButton-likedSongsIcon {
+border-radius: var(--border-radius);
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) {
+grid-area: episodes;
+margin: -6px 0 0 12px;
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) a {
+padding: 0;
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) a .main-yourEpisodesButton-yourEpisodesIcon {
+border-radius: var(--border-radius);
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) a .main-collectionLinkButton-collectionLinkText {
+display: none;
+}
+:root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:last-child {
+grid-area: playlists;
+}
+:root .Root__nav-bar .main-rootlist-rootlistDividerContainer {
+display: none;
+}
+:root .Root__nav-bar .main-rootlist-rootlist {
+margin-top: 0;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content {
+padding-top: 16px !important;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content::before {
+content: "Playlists";
+visibility: visible;
+width: unset;
+height: unset;
+line-height: unset;
+display: block;
+font-size: 16px;
+text-align: center;
+font-weight: bold;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] {
+margin: 12px;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"]:not(#spicetify-playlist-list) {
+margin: 12px 0 0 0;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div {
+contain: unset;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) {
+background-color: rgba(0, 0, 0, 0.1);
+border-radius: 8px;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem {
+padding: 0;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink {
+padding-top: 4px;
+padding-bottom: 4px;
+padding-left: calc(12px + var(--indentation)*var(--left-sidebar-item-indentation-width));
+padding-right: var(--left-sidebar-padding-right);
+box-sizing: content-box;
+transition: 150ms background-color;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink + button {
+border-radius: 0 !important;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink + div > button {
+margin-left: 0;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover + * {
+background-color: #3A3A3A40;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-statusIcons:not(:empty) {
+-webkit-margin-start: 0;
+        margin-inline-start: 0;
+padding: 4px 12px;
+transition: 150ms background-color;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-expandArrow {
+height: unset;
+margin-left: 0;
+padding: 4px 12px;
+transition: 150ms background-color;
+}
+:root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) li:last-child::after {
+position: absolute;
+content: "";
+width: 100px;
+height: 40px;
+}
+:root .Root__nav-bar .main-coverSlotExpanded-container .cover-art .cover-art-image {
+border-radius: 0;
+}
+:root .Root__nav-bar .os-scrollbar {
+top: 52px;
+bottom: 38px;
+border-top-right-radius: calc(var(--border-radius) + 5px);
+border-bottom-right-radius: calc(var(--border-radius) + 5px);
+overflow: hidden;
+}
 :root .Root__now-playing-bar .main-nowPlayingBar-container {
-  position: relative;
-  border-top: none;
-  background-color: transparent;
+position: relative;
+border-top: none;
+background-color: transparent;
 }
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar {
-  box-sizing: content-box;
-  padding-bottom: 16px;
+box-sizing: content-box;
+padding-bottom: 16px;
 }
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying.main-nowPlayingWidget-coverExpanded {
-  transform: translateX(-100px);
+  transform: translateX(-125px);
+}
+:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying.main-nowPlayingWidget-coverExpanded .main-coverSlotCollapsed-container {
+opacity: 0;
 }
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying .main-coverSlotCollapsed-container {
-  top: -20px;
+top: -20px;
 }
-:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying .main-coverSlotCollapsed-container .cover-art {
-  width: 84px !important;
-  height: 84px !important;
-  border-radius: var(--border-radius);
-  overflow: hidden;
-}
+
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-connectBar-connectBar {
-  position: absolute;
-  top: -15px;
-  right: 15px;
-  padding: 4px 8px;
-  box-sizing: content-box;
-  border-radius: var(--border-radius);
-  color: #fff;
-  background-color: var(--spice-sidebar);
+position: absolute;
+top: -15px;
+right: 15px;
+padding: 4px 8px;
+box-sizing: content-box;
+border-radius: var(--border-radius);
+color: #fff;
+background-color: var(--spice-sidebar);
 }
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-connectBar-connectBar::after {
-  content: none;
+content: none;
 }
 :root .Root__now-playing-bar .playback-bar {
-  position: absolute;
-  display: grid;
-  grid-template-columns: auto auto;
-  grid-template-areas: "time-left time-right" "bar bar";
-  bottom: 0;
+position: absolute;
+display: grid;
+grid-template-columns: auto auto;
+grid-template-areas: "time-left time-right" "bar bar";
+bottom: 0;
 }
 :root .Root__now-playing-bar .playback-bar .saber-hilt {
-  height: 0;
+height: 0;
 }
 :root .Root__now-playing-bar .playback-bar .playback-progressbar {
-  grid-column: 1/3;
-  grid-area: bar;
+grid-column: 1/3;
+grid-area: bar;
 }
 :root .Root__now-playing-bar .playback-bar .playback-progressbar > div > div {
-  --progress-bar-height: 12px;
-  --progress-bar-radius: 0;
+--progress-bar-height: 12px;
+--progress-bar-radius: 0;
 }
 :root .Root__now-playing-bar .playback-bar .playback-progressbar > div > div > div > div {
-  width: 105%;
-  background-color: transparent;
-  background-image: linear-gradient(90deg, #ffffff 93%, transparent 100%);
+width: 105%;
+background-color: transparent;
+background-image: linear-gradient(90deg, var(--spice-progress-bar) 93%, transparent 100%);
 }
 :root .Root__now-playing-bar .playback-bar .playback-progressbar .progress-bar__slider {
-  display: none;
+display: none;
 }
 :root .Root__now-playing-bar .playback-bar > div:first-of-type {
-  grid-area: time-left;
+grid-area: time-left;
 }
 :root .Root__now-playing-bar .playback-bar > div:last-of-type {
-  grid-area: time-right;
+grid-area: time-right;
 }
 :root .Root__now-playing-bar .playback-bar button {
-  width: 0;
+width: 0;
 }
 
 .x-settings-container {
-  max-width: unset;
+max-width: unset;
 }
 .x-settings-container .x-toggle-indicatorWrapper {
-  border-radius: var(--border-radius);
+border-radius: var(--border-radius);
 }
 
 :root .Root__top-bar header button {
-  border-radius: var(--border-radius);
+border-radius: var(--border-radius);
 }
 :root .Root__top-bar header button[title="Popup Lyrics"] {
-  background-image: url("https://i.imgur.com/91fuU3P.png");
-  background-size: 60%;
-  background-position: center;
-  background-repeat: no-repeat;
+background-image: url("https://i.imgur.com/91fuU3P.png");
+background-size: 60%;
+background-position: center;
+background-repeat: no-repeat;
 }
 :root .Root__top-bar header button[title="Popup Lyrics"] svg {
-  display: none;
+display: none;
 }
 :root .Root__top-bar header .main-topBar-historyButtons button, :root .Root__top-bar header .lyrics-tabBar-active {
-  background-color: rgba(11, 11, 17, 0.32);
+background-color: rgba(11, 11, 17, 0.32);
 }
 :root .Root__top-bar header .main-topBar-UpgradeButton {
-  font-size: 0;
-  overflow: hidden;
-  background: url("https://i.imgur.com/nzAfcIL.png") 50%/contain no-repeat;
-  border: none;
-  padding: 5px;
-  box-sizing: content-box;
+font-size: 0;
+overflow: hidden;
+background: url("https://i.imgur.com/nzAfcIL.png") 50%/contain no-repeat;
+border: none;
+padding: 5px;
+box-sizing: content-box;
 }
 :root .Root__top-bar header .main-userWidget-box {
-  height: unset;
-  padding: 0;
-  gap: 12px;
+height: unset;
+padding: 0;
+gap: 12px;
 }
 :root .Root__top-bar header .main-userWidget-box .main-avatar-avatar {
-  width: 40px !important;
-  height: 40px !important;
-  display: flex;
+width: 40px !important;
+height: 40px !important;
+display: flex;
 }
 @media (min-width: 1024px) {
-  :root .Root__top-bar header .main-userWidget-box .main-avatar-avatar .main-avatar-image {
-    border-radius: var(--border-radius) 0 0 var(--border-radius);
-  }
+:root .Root__top-bar header .main-userWidget-box .main-avatar-avatar .main-avatar-image {
+  border-radius: var(--border-radius) 0 0 var(--border-radius);
+}
 }
 :root .Root__top-bar header .main-userWidget-box .main-avatar-avatar > div {
-  width: unset !important;
-  height: unset !important;
+width: unset !important;
+height: unset !important;
 }
 :root .Root__top-bar header .main-userWidget-box .main-userWidget-displayName {
-  padding-right: 12px;
+padding-right: 12px;
 }
 :root .Root__top-bar header .main-userWidget-box .main-userWidget-chevron {
-  display: none;
+display: none;
 }
 
 .Root__main-view > div:first-of-type > div, .desktoproutes-homepage-takeover-ad-hptoComponent-parentContainer {
-  display: none;
+display: block;
 }
 
 :root {
-  --border-radius: 8px;
+--border-radius: 8px;
 }
 :root button, :root input, :root img {
-  border-radius: var(--border-radius);
+border-radius: var(--border-radius);
 }
-:root .main-trackList-rowHeartButton *:not([fill=none]), :root .control-button-heart *:not([fill=none]) {
-  color: #d25050 !important;
-  fill: #d25050 !important;
-}
+
 :root .main-trackList-rowSectionEnd .main-addButton-active, :root .main-trackList-rowSectionEnd .main-addButton-active:focus, :root .main-trackList-rowSectionEnd .main-addButton-active:hover {
-  color: #d25050;
+color: #d25050;
 }
 :root .lyrics-lyricsContainer-LyricsBackground {
-  background-repeat: no-repeat;
-  background-size: cover;
-  -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
-  mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
+background-repeat: no-repeat;
+background-size: cover;
+-webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
+mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
 }
 :root #context-menu {
-  overflow: hidden;
+overflow: hidden;
 }
 :root #context-menu ul {
-  padding: 0;
-  background-color: var(--spice-player);
+padding: 0;
+background-color: var(--spice-player);
 }
 :root #context-menu ul button, :root #context-menu ul a {
-  border-radius: 0;
+border-radius: 0;
 }
 :root #context-menu ul button::before, :root #context-menu ul button::after, :root #context-menu ul a::before, :root #context-menu ul a::after {
-  content: none;
+content: none;
 }
 :root #context-menu ul button:not(.main-contextMenu-disabled):focus, :root #context-menu ul button:not(.main-contextMenu-disabled):hover, :root #context-menu ul button[aria-expanded=true], :root #context-menu ul a:not(.main-contextMenu-disabled):focus, :root #context-menu ul a:not(.main-contextMenu-disabled):hover, :root #context-menu ul a[aria-expanded=true] {
-  background-color: rgba(92, 110, 177, 0.1647058824);
-  transition: 150ms background-color;
+background-color: #5c6eb12a;
+transition: 150ms background-color;
 }
 :root #bookmark-menu {
-  background-color: var(--spice-player);
-  border-radius: var(--border-radius);
+background-color: var(--spice-player);
+border-radius: var(--border-radius);
 }
 :root #bookmark-menu .bookmark-filter {
-  background-color: var(--spice-player);
+background-color: var(--spice-player);
 }
 :root #bookmark-menu button, :root #bookmark-menu a {
-  border-radius: 0;
+border-radius: 0;
 }
 :root #bookmark-menu button::before, :root #bookmark-menu button::after, :root #bookmark-menu a::before, :root #bookmark-menu a::after {
-  content: none;
+content: none;
 }
 :root #bookmark-menu button:not(.main-contextMenu-disabled):focus, :root #bookmark-menu button:not(.main-contextMenu-disabled):hover, :root #bookmark-menu button[aria-expanded=true], :root #bookmark-menu a:not(.main-contextMenu-disabled):focus, :root #bookmark-menu a:not(.main-contextMenu-disabled):hover, :root #bookmark-menu a[aria-expanded=true] {
-  background-color: rgba(92, 110, 177, 0.1647058824);
-  transition: 150ms background-color;
+background-color: #5c6eb12a;
+transition: 150ms background-color;
 }

--- a/Comfy-Chromatic/app.css
+++ b/Comfy-Chromatic/app.css
@@ -396,141 +396,133 @@ background-color: var(--spice-subtext) !important;
   height: 60px;
 }
 :root .Root__main-view #preloadImage {
-position: absolute;
-width: 0;
-height: 0;
-overflow: hidden;
-z-index: -1;
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  z-index: -1;
 }
 :root .Root__main-view #mainImage {
-position: absolute;
-width: 100%;
-height: 100%;
-top: 0;
-left: 0;
-background-size: 100%;
-background-repeat: no-repeat;
-background-position: center;
-will-change: transform;
-z-index: -1;
-transition: 300ms background-image ease-in-out;
-filter: blur(4px);
--webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background-size: 100%;
+  background-repeat: no-repeat;
+  background-position: center;
+  will-change: transform;
+  z-index: -1;
+  transition: 300ms background-image ease-in-out;
+  filter: blur(4px);
+  -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
+  mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
 }
 @media (max-width: 1500px) {
-:root .Root__main-view #mainImage {
-  background-position: top;
-}
+  :root .Root__main-view #mainImage {
+    background-position: top;
+  }
 }
 :root .Root__main-view .main-view-container__scroll-node-child {
-padding-bottom: 0;
+  padding-bottom: 0;
 }
 :root .Root__main-view .main-card-card {
-border-radius: var(--border-radius);
-padding: 0;
-overflow: hidden;
+  border-radius: var(--border-radius);
+  padding: 0;
+  overflow: hidden;
 }
 :root .Root__main-view .main-card-card .main-card-imageContainer {
-margin-bottom: -4px;
+  margin-bottom: -4px;
 }
 :root .Root__main-view .main-card-card .main-card-imageContainer .main-cardImage-circular, :root .Root__main-view .main-card-card .main-card-imageContainer img {
-border-radius: 0;
+  border-radius: 0;
 }
 :root .Root__main-view .main-card-card .main-card-cardMetadata {
-padding: 16px;
+  padding: 16px;
 }
 :root .Root__main-view .main-entityHeader-container .main-entityHeader-backgroundColor {
-background: none !important;
+  background: none !important;
 }
 :root .Root__main-view .main-entityHeader-container {
-padding: 32px;
-justify-content: center;
+  padding: 32px;
+  justify-content: center;
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) {
-align-self: center;
+  align-self: center;
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) + .main-entityHeader-headerText {
-flex: unset;
-justify-content: center;
+  flex: unset;
+  justify-content: center;
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) + .main-entityHeader-headerText .main-entityHeader-title h1 {
-font-size: 50px !important;
+  font-size: 50px !important;
 }
 :root .Root__main-view .main-yourEpisodes-yourEpisodesContentWrapper {
-max-width: unset;
+  max-width: unset;
 }
-#main > div > div.Root__top-container > div.Root__main-view > main > div.os-host.os-host-foreign.os-theme-spotify.os-host-resize-disabled.os-host-scrollbar-horizontal-hidden.main-view-container__scroll-node.os-host-transition.os-host-overflow.os-host-overflow-y > div.os-padding > div > div > div.main-view-container__scroll-node-child > section > div > div.iB16LxoPzDeVZo8zPhPQ > div.main-actionBarBackground-background {
-background: linear-gradient(rgba(255, 255, 255, 0.8) 0,
-var(--spice-main) 232px),
-var(--background-noise) !important;
-height: calc(100% - 243px);
-
-}
-
 :root .Root__main-view .main-actionBarBackground-background {
-background: linear-gradient(rgba(0, 0, 0, 0.6) 0,
-var(--spice-main) 232px),
-var(--background-noise) !important;
-height: calc(100% - 243px);
-
+  background: linear-gradient(rgba(var(--spice-rgb-shadow), 0.6) 0, var(--spice-main) 232px), var(--background-noise) !important;
+  height: calc(100% - 243px);
 }
-
+:root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar {
+  padding: 8px 16px 16px 16px;
+}
 :root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar .main-playButton-PlayButton {
-margin-top: -24px;
-margin-left: 8px;
-margin-right: 22px;
+  margin-top: -24px;
+  margin-left: 8px;
+  margin-right: 22px;
 }
 @media (min-width: 1024px) {
-:root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar .main-playButton-PlayButton {
-  margin-left: 24px;
-}
+  :root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar .main-playButton-PlayButton {
+    margin-left: 24px;
+  }
 }
 :root .Root__main-view section[data-testid=your-episodes-page] > .contentSpacing > section {
-height: calc(100vh - 494px);
+  height: calc(100vh - 494px);
 }
 :root .Root__main-view section[data-testid=your-episodes-page] > .main-yourEpisodes-yourEpisodesContentWrapper {
-height: calc(100vh - 438px);
+  height: calc(100vh - 438px);
 }
 :root .Root__main-view section[data-testid=your-episodes-page] > .main-yourEpisodes-yourEpisodesContentWrapper [data-testid^=episode-] {
-margin: 0;
+  margin: 0;
 }
-:root .Root__main-view section[data-testid=playlist-page] > div:last-child, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2), :root .Root__main-view section[data-testid=episode] > div:last-child, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child {
-background: none;
+:root .Root__main-view section[data-testid=playlist-page] > div:last-child, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2), :root .Root__main-view section[data-testid=episode] > div:last-child, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child {
+  background: none;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid {
-border-radius: var(--border-radius);
-border: none;
-padding-left: 10px;
-transition: 200ms background-color;
+  border-radius: var(--border-radius);
+  border: none;
+  padding-left: 10px;
+  transition: 200ms background-color;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid .main-type-mesto, :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid .main-type-ballad, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid .main-type-mesto, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid .main-type-ballad, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid .main-type-mesto, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid .main-type-ballad, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid .main-type-mesto, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid .main-type-ballad, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid .main-type-mesto, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid .main-type-ballad {
-transition: 300ms color;
+  transition: 300ms color;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid:hover {
-background-color: #3A3A3A40;
+  background-color: rgba(255, 255, 255, 0.05);
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe {
-background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.1);
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListHeader, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListHeader, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListHeader, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListHeader, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListHeader {
-display: none;
+  display: none;
 }
 :root .Root__main-view section[data-testid] {
-position: relative;
+  position: relative;
 }
-
-:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex {
-position: absolute;
-z-index: 1000;
-top: 8px;
-left: 10px;
-width: 40px;
-height: 40px;
-justify-content: center;
-text-indent: -1000px;
+:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackListRow {
+  grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [last] minmax(120px, 1fr) !important;
 }
-
+:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex {
+  position: absolute;
+  z-index: 1000;
+  top: 8px;
+  left: 10px;
+  width: 40px;
+  height: 40px;
+  justify-content: center;
+  text-indent: -1000px;
+}
 .main-entityHeader-background.main-entityHeader-gradient {
   -webkit-animation: background-animation 1s linear;
   animation: background-animation 1s linear;
@@ -546,459 +538,452 @@ text-indent: -1000px;
   -webkit-transform: scale(1.1);
   transform: scale(1.0);
 }
-
 :root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackList[aria-colcount="6"] .main-trackList-trackListRow, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackList[aria-colcount="6"] .main-trackList-trackListRow {
-grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [var3] minmax(120px, 2fr) [last] minmax(120px, 1fr) !important;
+  grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [var3] minmax(120px, 2fr) [last] minmax(120px, 1fr) !important;
 }
-
-
-
-:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow {
-  grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [last] minmax(120px, 1fr) !important;
-}
-
-
 
 :root .Root__nav-bar {
-overflow: hidden;
+  overflow: hidden;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints {
--moz-column-gap: 16px;
-     column-gap: 16px;
-padding: 0 12px;
-box-sizing: content-box;
-transition: 350ms background-color;
-border-radius: var(--border-radius) var(--border-radius) 0 0;
-margin: 24px 12px 0 12px;
-background-color: rgba(0, 0, 0, 0.1);
+  column-gap: 16px;
+  padding: 0 12px;
+  box-sizing: content-box;
+  transition: 350ms background-color;
+  border-radius: var(--border-radius) var(--border-radius) 0 0;
+  margin: 24px 12px 0 12px;
+  background-color: rgba(0, 0, 0, 0.1);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list {
-display: grid;
-grid-template-areas: "home home home home" "search search search search" "collection collection collection collection" "lyrics-plus lyrics-plus lyrics-plus lyrics-plus" "reddit reddit reddit reddit" "new-releases new-releases new-releases new-releases" "marketplace marketplace marketplace marketplace" "add tracks episodes .";
-grid-template-columns: 25px 25px 25px 1fr;
-border-radius: var(--border-radius);
+  display: grid;
+  grid-template-areas: "home home home home" "search search search search" "collection collection collection collection" "lyrics-plus lyrics-plus lyrics-plus lyrics-plus" "reddit reddit reddit reddit" "new-releases new-releases new-releases new-releases" "marketplace marketplace marketplace marketplace" "add tracks episodes .";
+  grid-template-columns: 25px 25px 25px 1fr;
+  border-radius: var(--border-radius);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/"] {
-grid-area: home;
+  grid-area: home;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/search"] {
-grid-area: search;
+  grid-area: search;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/collection"] {
-grid-area: collection;
+  grid-area: collection;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/lyrics-plus"] {
-grid-area: lyrics-plus;
+  grid-area: lyrics-plus;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/reddit"] {
-grid-area: reddit;
+  grid-area: reddit;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/new-releases"] {
-grid-area: new-releases;
+  grid-area: new-releases;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/spicetify-marketplace"] {
-grid-area: marketplace;
+:root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id$=marketplace] {
+  grid-area: marketplace;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list div[data-id="/add"] {
-grid-area: add;
+  grid-area: add;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list div[data-id="/collection/episodes"] {
-grid-area: episodes;
+  grid-area: episodes;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list div[data-id="/collection/tracks"] {
-grid-area: tracks;
+  grid-area: tracks;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li {
-padding: 0;
-margin: 0 -12px;
+  padding: 0;
+  margin: 0 -12px;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a {
-padding: 0 12px;
-border-radius: 0;
-background-color: transparent;
+  padding: 0 12px;
+  border-radius: 0;
+  background-color: transparent;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a.main-navBar-navBarLinkActive {
-background-color: #5c6eb12a;
+  background-color: rgba(92, 110, 177, 0.1647058824);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a svg > * {
-display: none;
+  display: none;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li:first-child a {
-border-radius: var(--border-radius) var(--border-radius) 0 0;
+  border-radius: var(--border-radius) var(--border-radius) 0 0;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div {
-padding: 0;
-margin: 2px 0;
+  padding: 0;
+  margin: 2px 0;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div > *.active {
-background: none;
+  background: none;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div button, :root .Root__nav-bar ul.main-navBar-entryPoints > div a {
-padding: 0;
+  padding: 0;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div button div, :root .Root__nav-bar ul.main-navBar-entryPoints > div a div {
-margin-right: 0;
-border-radius: var(--border-radius);
+  margin-right: 0;
+  border-radius: var(--border-radius);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div button div.main-rootlist-statusIcons, :root .Root__nav-bar ul.main-navBar-entryPoints > div a div.main-rootlist-statusIcons {
-display: none;
+  display: none;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > div button span, :root .Root__nav-bar ul.main-navBar-entryPoints > div a span {
-display: none;
+  display: none;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/"] .home-icon {
-background: url("https://i.imgur.com/jqDH9TQ.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/jqDH9TQ.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/"] .home-active-icon {
-background: url("https://i.imgur.com/60h58oZ.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/60h58oZ.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/search"] .search-icon {
-background: url("https://i.imgur.com/UV5JQpE.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/UV5JQpE.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/search"] .search-active-icon {
-background: url("https://i.imgur.com/CTVdQ3d.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/CTVdQ3d.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/collection"] .collection-icon {
-background: url("https://i.imgur.com/alXGfxW.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/alXGfxW.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/collection"] .collection-active-icon {
-background: url("https://i.imgur.com/SzvrAfr.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/SzvrAfr.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/lyrics-plus"] .collection-icon {
-background: url("https://i.imgur.com/91fuU3P.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/91fuU3P.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/lyrics-plus"] .collection-active-icon {
-background: url("https://i.imgur.com/EgRCYe8.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/EgRCYe8.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/reddit"] .collection-icon {
-background: url("https://i.imgur.com/6N6ev2V.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/6N6ev2V.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/reddit"] .collection-active-icon {
-background: url("https://i.imgur.com/UENFDdo.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/UENFDdo.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/new-releases"] .collection-icon {
-background: url("https://i.imgur.com/BgkCeDG.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/BgkCeDG.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/new-releases"] .collection-active-icon {
-background: url("https://i.imgur.com/CTRVDwF.png") center/cover no-repeat;
+  background: url("https://i.imgur.com/CTRVDwF.png") center/cover no-repeat;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints a[href="/spicetify-marketplace"] .collection-icon {
-background: url("https://i.imgur.com/2pWNa48.png") center/cover no-repeat;
+:root .Root__nav-bar ul.main-navBar-entryPoints a[href$=marketplace] .collection-icon {
+  background: url("https://i.imgur.com/2pWNa48.png") center/cover no-repeat;
 }
-
-:root .Root__nav-bar ul.main-navBar-entryPoints a[href="/spicetify-marketplace"] .collection-active-icon {
-background: url("https://i.imgur.com/rKmXQ6V.png") center/cover no-repeat;
+:root .Root__nav-bar ul.main-navBar-entryPoints a[href$=marketplace] .collection-active-icon {
+  background: url("https://i.imgur.com/rKmXQ6V.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div {
-display: grid;
-grid-template-areas: "add tracks episodes" "playlists playlists playlists";
-grid-template-columns: 25px 25px 1fr;
-grid-template-rows: 25px 1fr;
--moz-column-gap: 16px;
-     column-gap: 16px;
-margin: 12px 12px 0 12px;
+  display: grid;
+  grid-template-areas: "add tracks episodes" "playlists playlists playlists";
+  grid-template-columns: 25px 25px 1fr;
+  grid-template-rows: 25px 1fr;
+  column-gap: 16px;
+  margin: 12px 12px 0 12px;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child {
-grid-area: add;
-margin: -6px 0 0 12px;
+  grid-area: add;
+  margin: -6px 0 0 12px;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child::before {
-content: "";
-position: absolute;
-width: calc(100% - 24px);
-height: 40px;
-margin: -6px 0 0 -12px;
-background-color: rgba(0, 0, 0, 0.1);
-border-radius: 0 0 var(--border-radius) var(--border-radius);
+  content: "";
+  position: absolute;
+  width: calc(100% - 24px);
+  height: 40px;
+  margin: -6px 0 0 -12px;
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child button {
-padding: 0;
+  padding: 0;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child button .main-createPlaylistButton-createPlaylistIcon {
-border-radius: var(--border-radius);
+  border-radius: var(--border-radius);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(2) {
-grid-area: tracks;
-margin: -6px 0 0 12px;
+  grid-area: tracks;
+  margin: -6px 0 0 12px;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(2) a {
-padding: 0;
+  padding: 0;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(2) a .main-likedSongsButton-likedSongsIcon {
-border-radius: var(--border-radius);
+  border-radius: var(--border-radius);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) {
-grid-area: episodes;
-margin: -6px 0 0 12px;
+  grid-area: episodes;
+  margin: -6px 0 0 12px;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) a {
-padding: 0;
+  padding: 0;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) a .main-yourEpisodesButton-yourEpisodesIcon {
-border-radius: var(--border-radius);
+  border-radius: var(--border-radius);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:nth-child(3) a .main-collectionLinkButton-collectionLinkText {
-display: none;
+  display: none;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:last-child {
-grid-area: playlists;
+  grid-area: playlists;
 }
 :root .Root__nav-bar .main-rootlist-rootlistDividerContainer {
-display: none;
+  display: none;
 }
 :root .Root__nav-bar .main-rootlist-rootlist {
-margin-top: 0;
+  margin-top: 0;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content {
-padding-top: 16px !important;
+  padding-top: 16px !important;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content::before {
-content: "Playlists";
-visibility: visible;
-width: unset;
-height: unset;
-line-height: unset;
-display: block;
-font-size: 16px;
-text-align: center;
-font-weight: bold;
+  content: "Playlists";
+  visibility: visible;
+  width: unset;
+  height: unset;
+  line-height: unset;
+  display: block;
+  font-size: 16px;
+  text-align: center;
+  font-weight: bold;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] {
-margin: 12px;
+  margin: 12px;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"]:not(#spicetify-playlist-list) {
-margin: 12px 0 0 0;
+  margin: 12px 0 0 0;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div {
-contain: unset;
+  contain: unset;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) {
-background-color: rgba(0, 0, 0, 0.1);
-border-radius: 8px;
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem {
-padding: 0;
+  padding: 0;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink {
-padding-top: 4px;
-padding-bottom: 4px;
-padding-left: calc(12px + var(--indentation)*var(--left-sidebar-item-indentation-width));
-padding-right: var(--left-sidebar-padding-right);
-box-sizing: content-box;
-transition: 150ms background-color;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-left: calc(12px + var(--indentation) * var(--left-sidebar-item-indentation-width));
+  padding-right: var(--left-sidebar-padding-right);
+  box-sizing: content-box;
+  transition: 150ms background-color;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink + button {
-border-radius: 0 !important;
+  border-radius: 0 !important;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink + div > button {
-margin-left: 0;
+  margin-left: 0;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover + * {
-background-color: #3A3A3A40;
+  background-color: rgba(92, 110, 177, 0.1647058824);
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-statusIcons:not(:empty) {
--webkit-margin-start: 0;
-        margin-inline-start: 0;
-padding: 4px 12px;
-transition: 150ms background-color;
+  margin-inline-start: 0;
+  padding: 4px 12px;
+  transition: 150ms background-color;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-expandArrow {
-height: unset;
-margin-left: 0;
-padding: 4px 12px;
-transition: 150ms background-color;
+  height: unset;
+  margin-left: 0;
+  padding: 4px 12px;
+  transition: 150ms background-color;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) li:last-child::after {
-position: absolute;
-content: "";
-width: 100px;
-height: 40px;
+  position: absolute;
+  content: "";
+  width: 100px;
+  height: 40px;
 }
 :root .Root__nav-bar .main-coverSlotExpanded-container .cover-art .cover-art-image {
-border-radius: 0;
+  border-radius: 0;
 }
 :root .Root__nav-bar .os-scrollbar {
-top: 52px;
-bottom: 38px;
-border-top-right-radius: calc(var(--border-radius) + 5px);
-border-bottom-right-radius: calc(var(--border-radius) + 5px);
-overflow: hidden;
-}
-:root .Root__now-playing-bar .main-nowPlayingBar-container {
-position: relative;
-border-top: none;
-background-color: transparent;
-}
-:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar {
-box-sizing: content-box;
-padding-bottom: 16px;
-}
-:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying.main-nowPlayingWidget-coverExpanded {
-  transform: translateX(-125px);
-}
-:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying.main-nowPlayingWidget-coverExpanded .main-coverSlotCollapsed-container {
-opacity: 0;
-}
-:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying .main-coverSlotCollapsed-container {
-top: -20px;
+  top: 52px;
+  bottom: 38px;
+  border-top-right-radius: calc(var(--border-radius) + 5px);
+  border-bottom-right-radius: calc(var(--border-radius) + 5px);
+  overflow: hidden;
 }
 
+:root .Root__now-playing-bar .main-nowPlayingBar-container {
+  position: relative;
+  border-top: none;
+  background-color: transparent;
+}
+:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar {
+  box-sizing: content-box;
+  padding-bottom: 16px;
+}
+:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying.main-nowPlayingWidget-coverExpanded {
+  transform: translateX(-100px);
+}
+:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying .main-coverSlotCollapsed-container {
+  top: -20px;
+}
+:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying .main-coverSlotCollapsed-container .cover-art {
+  width: 84px !important;
+  height: 84px !important;
+  border-radius: var(--border-radius);
+  overflow: hidden;
+}
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-connectBar-connectBar {
-position: absolute;
-top: -15px;
-right: 15px;
-padding: 4px 8px;
-box-sizing: content-box;
-border-radius: var(--border-radius);
-color: #fff;
-background-color: var(--spice-sidebar);
+  position: absolute;
+  top: -15px;
+  right: 15px;
+  padding: 4px 8px;
+  box-sizing: content-box;
+  border-radius: var(--border-radius);
+  color: #fff;
+  background-color: var(--spice-sidebar);
 }
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-connectBar-connectBar::after {
-content: none;
+  content: none;
 }
 :root .Root__now-playing-bar .playback-bar {
-position: absolute;
-display: grid;
-grid-template-columns: auto auto;
-grid-template-areas: "time-left time-right" "bar bar";
-bottom: 0;
+  position: absolute;
+  display: grid;
+  grid-template-columns: auto auto;
+  grid-template-areas: "time-left time-right" "bar bar";
+  bottom: 0;
 }
 :root .Root__now-playing-bar .playback-bar .saber-hilt {
-height: 0;
+  height: 0;
 }
 :root .Root__now-playing-bar .playback-bar .playback-progressbar {
-grid-column: 1/3;
-grid-area: bar;
+  grid-column: 1/3;
+  grid-area: bar;
 }
 :root .Root__now-playing-bar .playback-bar .playback-progressbar > div > div {
---progress-bar-height: 12px;
---progress-bar-radius: 0;
+  --progress-bar-height: 12px;
+  --progress-bar-radius: 0;
 }
 :root .Root__now-playing-bar .playback-bar .playback-progressbar > div > div > div > div {
-width: 105%;
-background-color: transparent;
-background-image: linear-gradient(90deg, var(--spice-progress-bar) 93%, transparent 100%);
+  width: 105%;
+  background-color: transparent;
+  background-image: linear-gradient(90deg, #ffffff 93%, transparent 100%);
 }
 :root .Root__now-playing-bar .playback-bar .playback-progressbar .progress-bar__slider {
-display: none;
+  display: none;
 }
 :root .Root__now-playing-bar .playback-bar > div:first-of-type {
-grid-area: time-left;
+  grid-area: time-left;
 }
 :root .Root__now-playing-bar .playback-bar > div:last-of-type {
-grid-area: time-right;
+  grid-area: time-right;
 }
 :root .Root__now-playing-bar .playback-bar button {
-width: 0;
+  width: 0;
 }
 
 .x-settings-container {
-max-width: unset;
+  max-width: unset;
 }
 .x-settings-container .x-toggle-indicatorWrapper {
-border-radius: var(--border-radius);
+  border-radius: var(--border-radius);
 }
 
 :root .Root__top-bar header button {
-border-radius: var(--border-radius);
+  border-radius: var(--border-radius);
 }
 :root .Root__top-bar header button[title="Popup Lyrics"] {
-background-image: url("https://i.imgur.com/91fuU3P.png");
-background-size: 60%;
-background-position: center;
-background-repeat: no-repeat;
+  background-image: url("https://i.imgur.com/91fuU3P.png");
+  background-size: 60%;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 :root .Root__top-bar header button[title="Popup Lyrics"] svg {
-display: none;
+  display: none;
 }
 :root .Root__top-bar header .main-topBar-historyButtons button, :root .Root__top-bar header .lyrics-tabBar-active {
-background-color: rgba(11, 11, 17, 0.32);
+  background-color: rgba(11, 11, 17, 0.32);
 }
 :root .Root__top-bar header .main-topBar-UpgradeButton {
-font-size: 0;
-overflow: hidden;
-background: url("https://i.imgur.com/nzAfcIL.png") 50%/contain no-repeat;
-border: none;
-padding: 5px;
-box-sizing: content-box;
+  font-size: 0;
+  overflow: hidden;
+  background: url("https://i.imgur.com/nzAfcIL.png") 50%/contain no-repeat;
+  border: none;
+  padding: 5px;
+  box-sizing: content-box;
 }
 :root .Root__top-bar header .main-userWidget-box {
-height: unset;
-padding: 0;
-gap: 12px;
+  height: unset;
+  padding: 0;
+  gap: 12px;
 }
 :root .Root__top-bar header .main-userWidget-box .main-avatar-avatar {
-width: 40px !important;
-height: 40px !important;
-display: flex;
+  width: 40px !important;
+  height: 40px !important;
+  display: flex;
 }
 @media (min-width: 1024px) {
-:root .Root__top-bar header .main-userWidget-box .main-avatar-avatar .main-avatar-image {
-  border-radius: var(--border-radius) 0 0 var(--border-radius);
-}
+  :root .Root__top-bar header .main-userWidget-box .main-avatar-avatar .main-avatar-image {
+    border-radius: var(--border-radius) 0 0 var(--border-radius);
+  }
 }
 :root .Root__top-bar header .main-userWidget-box .main-avatar-avatar > div {
-width: unset !important;
-height: unset !important;
+  width: unset !important;
+  height: unset !important;
 }
 :root .Root__top-bar header .main-userWidget-box .main-userWidget-displayName {
-padding-right: 12px;
+  padding-right: 12px;
 }
 :root .Root__top-bar header .main-userWidget-box .main-userWidget-chevron {
-display: none;
+  display: none;
 }
 
 .Root__main-view > div:first-of-type > div, .desktoproutes-homepage-takeover-ad-hptoComponent-parentContainer {
-display: block;
+  display: none;
 }
 
 :root {
---border-radius: 8px;
+  --border-radius: 8px;
 }
 :root button, :root input, :root img {
-border-radius: var(--border-radius);
+  border-radius: var(--border-radius);
 }
-
+:root .main-trackList-rowHeartButton *:not([fill=none]), :root .control-button-heart *:not([fill=none]) {
+  color: #d25050 !important;
+  fill: #d25050 !important;
+}
 :root .main-trackList-rowSectionEnd .main-addButton-active, :root .main-trackList-rowSectionEnd .main-addButton-active:focus, :root .main-trackList-rowSectionEnd .main-addButton-active:hover {
-color: #d25050;
+  color: #d25050;
 }
 :root .lyrics-lyricsContainer-LyricsBackground {
-background-repeat: no-repeat;
-background-size: cover;
--webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
+  background-repeat: no-repeat;
+  background-size: cover;
+  -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
+  mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
 }
 :root #context-menu {
-overflow: hidden;
+  overflow: hidden;
 }
 :root #context-menu ul {
-padding: 0;
-background-color: var(--spice-player);
+  padding: 0;
+  background-color: var(--spice-player);
 }
 :root #context-menu ul button, :root #context-menu ul a {
-border-radius: 0;
+  border-radius: 0;
 }
 :root #context-menu ul button::before, :root #context-menu ul button::after, :root #context-menu ul a::before, :root #context-menu ul a::after {
-content: none;
+  content: none;
 }
 :root #context-menu ul button:not(.main-contextMenu-disabled):focus, :root #context-menu ul button:not(.main-contextMenu-disabled):hover, :root #context-menu ul button[aria-expanded=true], :root #context-menu ul a:not(.main-contextMenu-disabled):focus, :root #context-menu ul a:not(.main-contextMenu-disabled):hover, :root #context-menu ul a[aria-expanded=true] {
-background-color: #5c6eb12a;
-transition: 150ms background-color;
+  background-color: rgba(92, 110, 177, 0.1647058824);
+  transition: 150ms background-color;
 }
 :root #bookmark-menu {
-background-color: var(--spice-player);
-border-radius: var(--border-radius);
+  background-color: var(--spice-player);
+  border-radius: var(--border-radius);
 }
 :root #bookmark-menu .bookmark-filter {
-background-color: var(--spice-player);
+  background-color: var(--spice-player);
 }
 :root #bookmark-menu button, :root #bookmark-menu a {
-border-radius: 0;
+  border-radius: 0;
 }
 :root #bookmark-menu button::before, :root #bookmark-menu button::after, :root #bookmark-menu a::before, :root #bookmark-menu a::after {
-content: none;
+  content: none;
 }
 :root #bookmark-menu button:not(.main-contextMenu-disabled):focus, :root #bookmark-menu button:not(.main-contextMenu-disabled):hover, :root #bookmark-menu button[aria-expanded=true], :root #bookmark-menu a:not(.main-contextMenu-disabled):focus, :root #bookmark-menu a:not(.main-contextMenu-disabled):hover, :root #bookmark-menu a[aria-expanded=true] {
-background-color: #5c6eb12a;
-transition: 150ms background-color;
+  background-color: rgba(92, 110, 177, 0.1647058824);
+  transition: 150ms background-color;
 }

--- a/Comfy-Chromatic/assets/_navbar.scss
+++ b/Comfy-Chromatic/assets/_navbar.scss
@@ -21,7 +21,7 @@
       li[data-id="/lyrics-plus"] { grid-area: lyrics-plus;}
       li[data-id="/reddit"] { grid-area: reddit;}
       li[data-id="/new-releases"] { grid-area: new-releases;}
-      li[data-id="/spicetify-marketplace"] { grid-area: marketplace;}
+      li[data-id$="marketplace"] { grid-area: marketplace;}
       div[data-id="/add"] { grid-area: add;}
       div[data-id="/collection/episodes"] { grid-area: episodes;}
       div[data-id="/collection/tracks"] { grid-area: tracks;}
@@ -58,7 +58,7 @@
       button, a {
         padding: 0;
 
-        div { 
+        div {
           margin-right: 0; border-radius: var(--border-radius);
 
           &.main-rootlist-statusIcons { display: none;}
@@ -98,7 +98,7 @@
       .collection-active-icon { background: url("https://i.imgur.com/CTRVDwF.png") center/cover no-repeat;}
     }
 
-    a[href="/spicetify-marketplace"] {
+    a[href$="marketplace"] {
       .collection-icon { background: url("https://i.imgur.com/2pWNa48.png") center/cover no-repeat;}
       .collection-active-icon { background: url("https://i.imgur.com/rKmXQ6V.png") center/cover no-repeat;}
     }
@@ -181,16 +181,16 @@
 
         & > div {
           contain: unset;
-        
+
           & > div:nth-child(2) {
             background-color: rgba(0, 0, 0, 0.1);
-            border-radius: 8px; 
+            border-radius: 8px;
 
             .main-rootlist-rootlistItem {
               padding: 0;
 
               .main-rootlist-rootlistItemLink {
-                padding-top: 4px; padding-bottom: 4px; 
+                padding-top: 4px; padding-bottom: 4px;
                 padding-left: calc(12px + var(--indentation)*var(--left-sidebar-item-indentation-width));
                 padding-right: var(--left-sidebar-padding-right);
                 box-sizing: content-box;
@@ -213,7 +213,7 @@
               }
             }
 
-            li:last-child::after { 
+            li:last-child::after {
               position: absolute;
               content: "";
               width: 100px; height: 40px;
@@ -228,7 +228,7 @@
   .main-coverSlotExpanded-container .cover-art .cover-art-image { border-radius: 0;}
 
   // Scrollbar
-  .os-scrollbar { 
+  .os-scrollbar {
     top: 52px; bottom: 38px;
     border-top-right-radius: calc(var(--border-radius) + 5px);
     border-bottom-right-radius: calc(var(--border-radius) + 5px);

--- a/Comfy-Mono/app.css
+++ b/Comfy-Mono/app.css
@@ -351,6 +351,7 @@ margin-right: 24px
   overflow: hidden;
   z-index: -1;
 }
+
 :root .Root__main-view #mainImage {
   position: absolute;
   width: 100%;
@@ -414,14 +415,17 @@ margin-right: 24px
   var(--spice-main) 232px),
   var(--background-noise) !important;
   height: calc(100% - 243px);
+
 }
+
 :root .Root__main-view .main-actionBarBackground-background {
-  background: linear-gradient(rgba(var(--spice-rgb-shadow), 0.6) 0, var(--spice-main) 232px), var(--background-noise) !important;
+  background: linear-gradient(rgba(255, 255, 255, 0.6) 0,
+  var(--spice-main) 232px),
+  var(--background-noise) !important;
   height: calc(100% - 243px);
+
 }
-:root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar {
-  padding: 8px 16px 16px 16px;
-}
+
 :root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar .main-playButton-PlayButton {
   margin-top: -24px;
   margin-left: 8px;
@@ -441,7 +445,7 @@ margin-right: 24px
 :root .Root__main-view section[data-testid=your-episodes-page] > .main-yourEpisodes-yourEpisodesContentWrapper [data-testid^=episode-] {
   margin: 0;
 }
-:root .Root__main-view section[data-testid=playlist-page] > div:last-child, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2), :root .Root__main-view section[data-testid=episode] > div:last-child, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child {
+:root .Root__main-view section[data-testid=playlist-page] > div:last-child, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2), :root .Root__main-view section[data-testid=episode] > div:last-child, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child {
   background: none;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid {
@@ -454,7 +458,7 @@ margin-right: 24px
   transition: 300ms color;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid:hover {
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: #3A3A3A40;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe {
   background-color: rgba(255, 255, 255, 0.1);
@@ -465,10 +469,8 @@ margin-right: 24px
 :root .Root__main-view section[data-testid] {
   position: relative;
 }
-:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackListRow {
-  grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [last] minmax(120px, 1fr) !important;
-}
-:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex {
+
+:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex {
   position: absolute;
   z-index: 1000;
   top: 8px;
@@ -478,6 +480,7 @@ margin-right: 24px
   justify-content: center;
   text-indent: -1000px;
 }
+
 .main-entityHeader-background.main-entityHeader-gradient {
     -webkit-animation: background-animation 1s linear;
     animation: background-animation 1s linear;
@@ -493,17 +496,25 @@ margin-right: 24px
     -webkit-transform: scale(1.1);
     transform: scale(1.0);
 }
+
 :root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackList[aria-colcount="6"] .main-trackList-trackListRow, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackList[aria-colcount="6"] .main-trackList-trackListRow {
   grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [var3] minmax(120px, 2fr) [last] minmax(120px, 1fr) !important;
 }
+
+
+
 :root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow {
     grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [last] minmax(120px, 1fr) !important;
 }
+
+
+
 :root .Root__nav-bar {
   overflow: hidden;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints {
-  column-gap: 16px;
+  -moz-column-gap: 16px;
+       column-gap: 16px;
   padding: 0 12px;
   box-sizing: content-box;
   transition: 350ms background-color;
@@ -535,7 +546,7 @@ margin-right: 24px
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/new-releases"] {
   grid-area: new-releases;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id$=marketplace] {
+:root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id$="marketplace"] {
   grid-area: marketplace;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list div[data-id="/add"] {
@@ -557,7 +568,7 @@ margin-right: 24px
   background-color: transparent;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a.main-navBar-navBarLinkActive {
-  background-color: rgba(92, 110, 177, 0.1647058824);
+  background-color: #5c6eb12a;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a svg > * {
   display: none;
@@ -621,10 +632,11 @@ margin-right: 24px
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/new-releases"] .collection-active-icon {
   background: url("https://i.imgur.com/CTRVDwF.png") center/cover no-repeat;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints a[href$=marketplace] .collection-icon {
+:root .Root__nav-bar ul.main-navBar-entryPoints a[href$="marketplace"] .collection-icon {
   background: url("https://i.imgur.com/2pWNa48.png") center/cover no-repeat;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints a[href$=marketplace] .collection-active-icon {
+
+:root .Root__nav-bar ul.main-navBar-entryPoints a[href$="marketplace"] .collection-active-icon {
   background: url("https://i.imgur.com/rKmXQ6V.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div {
@@ -632,7 +644,8 @@ margin-right: 24px
   grid-template-areas: "add tracks episodes" "playlists playlists playlists";
   grid-template-columns: 25px 25px 1fr;
   grid-template-rows: 25px 1fr;
-  column-gap: 16px;
+  -moz-column-gap: 16px;
+       column-gap: 16px;
   margin: 12px 12px 0 12px;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child {
@@ -719,7 +732,7 @@ margin-right: 24px
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink {
   padding-top: 4px;
   padding-bottom: 4px;
-  padding-left: calc(12px + var(--indentation) * var(--left-sidebar-item-indentation-width));
+  padding-left: calc(12px + var(--indentation)*var(--left-sidebar-item-indentation-width));
   padding-right: var(--left-sidebar-padding-right);
   box-sizing: content-box;
   transition: 150ms background-color;
@@ -731,10 +744,11 @@ margin-right: 24px
   margin-left: 0;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover + * {
-  background-color: rgba(92, 110, 177, 0.1647058824);
+  background-color: #3A3A3A40;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-statusIcons:not(:empty) {
-  margin-inline-start: 0;
+  -webkit-margin-start: 0;
+          margin-inline-start: 0;
   padding: 4px 12px;
   transition: 150ms background-color;
 }
@@ -760,7 +774,6 @@ margin-right: 24px
   border-bottom-right-radius: calc(var(--border-radius) + 5px);
   overflow: hidden;
 }
-
 :root .Root__now-playing-bar .main-nowPlayingBar-container {
   position: relative;
   border-top: none;
@@ -779,12 +792,7 @@ margin-right: 24px
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying .main-coverSlotCollapsed-container {
   top: -20px;
 }
-:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying .main-coverSlotCollapsed-container .cover-art {
-  width: 84px !important;
-  height: 84px !important;
-  border-radius: var(--border-radius);
-  overflow: hidden;
-}
+
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-connectBar-connectBar {
   position: absolute;
   top: -15px;
@@ -891,7 +899,7 @@ margin-right: 24px
 }
 
 .Root__main-view > div:first-of-type > div, .desktoproutes-homepage-takeover-ad-hptoComponent-parentContainer {
-  display: none;
+  display: block;
 }
 
 :root {
@@ -900,10 +908,7 @@ margin-right: 24px
 :root button, :root input, :root img {
   border-radius: var(--border-radius);
 }
-:root .main-trackList-rowHeartButton *:not([fill=none]), :root .control-button-heart *:not([fill=none]) {
-  color: #d25050 !important;
-  fill: #d25050 !important;
-}
+
 :root .main-trackList-rowSectionEnd .main-addButton-active, :root .main-trackList-rowSectionEnd .main-addButton-active:focus, :root .main-trackList-rowSectionEnd .main-addButton-active:hover {
   color: #d25050;
 }
@@ -927,7 +932,7 @@ margin-right: 24px
   content: none;
 }
 :root #context-menu ul button:not(.main-contextMenu-disabled):focus, :root #context-menu ul button:not(.main-contextMenu-disabled):hover, :root #context-menu ul button[aria-expanded=true], :root #context-menu ul a:not(.main-contextMenu-disabled):focus, :root #context-menu ul a:not(.main-contextMenu-disabled):hover, :root #context-menu ul a[aria-expanded=true] {
-  background-color: rgba(92, 110, 177, 0.1647058824);
+  background-color: #5c6eb12a;
   transition: 150ms background-color;
 }
 :root #bookmark-menu {
@@ -944,6 +949,6 @@ margin-right: 24px
   content: none;
 }
 :root #bookmark-menu button:not(.main-contextMenu-disabled):focus, :root #bookmark-menu button:not(.main-contextMenu-disabled):hover, :root #bookmark-menu button[aria-expanded=true], :root #bookmark-menu a:not(.main-contextMenu-disabled):focus, :root #bookmark-menu a:not(.main-contextMenu-disabled):hover, :root #bookmark-menu a[aria-expanded=true] {
-  background-color: rgba(92, 110, 177, 0.1647058824);
+  background-color: #5c6eb12a;
   transition: 150ms background-color;
 }

--- a/Comfy-Mono/app.css
+++ b/Comfy-Mono/app.css
@@ -351,7 +351,6 @@ margin-right: 24px
   overflow: hidden;
   z-index: -1;
 }
-
 :root .Root__main-view #mainImage {
   position: absolute;
   width: 100%;
@@ -415,17 +414,14 @@ margin-right: 24px
   var(--spice-main) 232px),
   var(--background-noise) !important;
   height: calc(100% - 243px);
-
 }
-
 :root .Root__main-view .main-actionBarBackground-background {
-  background: linear-gradient(rgba(255, 255, 255, 0.6) 0,
-  var(--spice-main) 232px),
-  var(--background-noise) !important;
+  background: linear-gradient(rgba(var(--spice-rgb-shadow), 0.6) 0, var(--spice-main) 232px), var(--background-noise) !important;
   height: calc(100% - 243px);
-
 }
-
+:root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar {
+  padding: 8px 16px 16px 16px;
+}
 :root .Root__main-view section[data-testid=playlist-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=album-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=your-episodes-page] .main-actionBar-ActionBar .main-playButton-PlayButton, :root .Root__main-view section[data-testid=artist-page] .main-actionBar-ActionBar .main-playButton-PlayButton {
   margin-top: -24px;
   margin-left: 8px;
@@ -445,7 +441,7 @@ margin-right: 24px
 :root .Root__main-view section[data-testid=your-episodes-page] > .main-yourEpisodes-yourEpisodesContentWrapper [data-testid^=episode-] {
   margin: 0;
 }
-:root .Root__main-view section[data-testid=playlist-page] > div:last-child, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2), :root .Root__main-view section[data-testid=episode] > div:last-child, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child {
+:root .Root__main-view section[data-testid=playlist-page] > div:last-child, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2), :root .Root__main-view section[data-testid=episode] > div:last-child, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child {
   background: none;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid {
@@ -458,7 +454,7 @@ margin-right: 24px
   transition: 300ms color;
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid:hover, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid:hover {
-  background-color: #3A3A3A40;
+  background-color: rgba(255, 255, 255, 0.05);
 }
 :root .Root__main-view section[data-testid=playlist-page] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=album-page] > div:nth-last-child(2) .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=episode] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=your-episodes-page] > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe, :root .Root__main-view section[data-testid=artist-page] > div > div:last-child .main-trackList-trackListRowGrid.vMOFJ7EasQXUloRrStEe {
   background-color: rgba(255, 255, 255, 0.1);
@@ -469,8 +465,10 @@ margin-right: 24px
 :root .Root__main-view section[data-testid] {
   position: relative;
 }
-
-:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex {
+:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackListRow {
+  grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [last] minmax(120px, 1fr) !important;
+}
+:root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackListRow > .main-trackList-rowSectionIndex {
   position: absolute;
   z-index: 1000;
   top: 8px;
@@ -480,7 +478,6 @@ margin-right: 24px
   justify-content: center;
   text-indent: -1000px;
 }
-
 .main-entityHeader-background.main-entityHeader-gradient {
     -webkit-animation: background-animation 1s linear;
     animation: background-animation 1s linear;
@@ -496,25 +493,17 @@ margin-right: 24px
     -webkit-transform: scale(1.1);
     transform: scale(1.0);
 }
-
 :root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackList[aria-colcount="6"] .main-trackList-trackListRow, :root .Root__main-view section[data-testid=artist-page] .main-trackList-trackList[aria-colcount="6"] .main-trackList-trackListRow {
   grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [var3] minmax(120px, 2fr) [last] minmax(120px, 1fr) !important;
 }
-
-
-
 :root .Root__main-view section[data-testid=playlist-page] .main-trackList-trackListRow {
     grid-template-columns: [first] 6fr [var1] 4fr [var2] 3fr [last] minmax(120px, 1fr) !important;
 }
-
-
-
 :root .Root__nav-bar {
   overflow: hidden;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints {
-  -moz-column-gap: 16px;
-       column-gap: 16px;
+  column-gap: 16px;
   padding: 0 12px;
   box-sizing: content-box;
   transition: 350ms background-color;
@@ -546,7 +535,7 @@ margin-right: 24px
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/new-releases"] {
   grid-area: new-releases;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/spicetify-marketplace"] {
+:root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id$=marketplace] {
   grid-area: marketplace;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list div[data-id="/add"] {
@@ -568,7 +557,7 @@ margin-right: 24px
   background-color: transparent;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a.main-navBar-navBarLinkActive {
-  background-color: #5c6eb12a;
+  background-color: rgba(92, 110, 177, 0.1647058824);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a svg > * {
   display: none;
@@ -632,11 +621,10 @@ margin-right: 24px
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/new-releases"] .collection-active-icon {
   background: url("https://i.imgur.com/CTRVDwF.png") center/cover no-repeat;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints a[href="/spicetify-marketplace"] .collection-icon {
+:root .Root__nav-bar ul.main-navBar-entryPoints a[href$=marketplace] .collection-icon {
   background: url("https://i.imgur.com/2pWNa48.png") center/cover no-repeat;
 }
-
-:root .Root__nav-bar ul.main-navBar-entryPoints a[href="/spicetify-marketplace"] .collection-active-icon {
+:root .Root__nav-bar ul.main-navBar-entryPoints a[href$=marketplace] .collection-active-icon {
   background: url("https://i.imgur.com/rKmXQ6V.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div {
@@ -644,8 +632,7 @@ margin-right: 24px
   grid-template-areas: "add tracks episodes" "playlists playlists playlists";
   grid-template-columns: 25px 25px 1fr;
   grid-template-rows: 25px 1fr;
-  -moz-column-gap: 16px;
-       column-gap: 16px;
+  column-gap: 16px;
   margin: 12px 12px 0 12px;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child {
@@ -732,7 +719,7 @@ margin-right: 24px
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink {
   padding-top: 4px;
   padding-bottom: 4px;
-  padding-left: calc(12px + var(--indentation)*var(--left-sidebar-item-indentation-width));
+  padding-left: calc(12px + var(--indentation) * var(--left-sidebar-item-indentation-width));
   padding-right: var(--left-sidebar-padding-right);
   box-sizing: content-box;
   transition: 150ms background-color;
@@ -744,11 +731,10 @@ margin-right: 24px
   margin-left: 0;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover + * {
-  background-color: #3A3A3A40;
+  background-color: rgba(92, 110, 177, 0.1647058824);
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-statusIcons:not(:empty) {
-  -webkit-margin-start: 0;
-          margin-inline-start: 0;
+  margin-inline-start: 0;
   padding: 4px 12px;
   transition: 150ms background-color;
 }
@@ -774,6 +760,7 @@ margin-right: 24px
   border-bottom-right-radius: calc(var(--border-radius) + 5px);
   overflow: hidden;
 }
+
 :root .Root__now-playing-bar .main-nowPlayingBar-container {
   position: relative;
   border-top: none;
@@ -792,7 +779,12 @@ margin-right: 24px
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying .main-coverSlotCollapsed-container {
   top: -20px;
 }
-
+:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying .main-coverSlotCollapsed-container .cover-art {
+  width: 84px !important;
+  height: 84px !important;
+  border-radius: var(--border-radius);
+  overflow: hidden;
+}
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-connectBar-connectBar {
   position: absolute;
   top: -15px;
@@ -899,7 +891,7 @@ margin-right: 24px
 }
 
 .Root__main-view > div:first-of-type > div, .desktoproutes-homepage-takeover-ad-hptoComponent-parentContainer {
-  display: block;
+  display: none;
 }
 
 :root {
@@ -908,7 +900,10 @@ margin-right: 24px
 :root button, :root input, :root img {
   border-radius: var(--border-radius);
 }
-
+:root .main-trackList-rowHeartButton *:not([fill=none]), :root .control-button-heart *:not([fill=none]) {
+  color: #d25050 !important;
+  fill: #d25050 !important;
+}
 :root .main-trackList-rowSectionEnd .main-addButton-active, :root .main-trackList-rowSectionEnd .main-addButton-active:focus, :root .main-trackList-rowSectionEnd .main-addButton-active:hover {
   color: #d25050;
 }
@@ -932,7 +927,7 @@ margin-right: 24px
   content: none;
 }
 :root #context-menu ul button:not(.main-contextMenu-disabled):focus, :root #context-menu ul button:not(.main-contextMenu-disabled):hover, :root #context-menu ul button[aria-expanded=true], :root #context-menu ul a:not(.main-contextMenu-disabled):focus, :root #context-menu ul a:not(.main-contextMenu-disabled):hover, :root #context-menu ul a[aria-expanded=true] {
-  background-color: #5c6eb12a;
+  background-color: rgba(92, 110, 177, 0.1647058824);
   transition: 150ms background-color;
 }
 :root #bookmark-menu {
@@ -949,6 +944,6 @@ margin-right: 24px
   content: none;
 }
 :root #bookmark-menu button:not(.main-contextMenu-disabled):focus, :root #bookmark-menu button:not(.main-contextMenu-disabled):hover, :root #bookmark-menu button[aria-expanded=true], :root #bookmark-menu a:not(.main-contextMenu-disabled):focus, :root #bookmark-menu a:not(.main-contextMenu-disabled):hover, :root #bookmark-menu a[aria-expanded=true] {
-  background-color: #5c6eb12a;
+  background-color: rgba(92, 110, 177, 0.1647058824);
   transition: 150ms background-color;
 }

--- a/Comfy-Mono/assets/_navbar.scss
+++ b/Comfy-Mono/assets/_navbar.scss
@@ -21,7 +21,7 @@
       li[data-id="/lyrics-plus"] { grid-area: lyrics-plus;}
       li[data-id="/reddit"] { grid-area: reddit;}
       li[data-id="/new-releases"] { grid-area: new-releases;}
-      li[data-id="/spicetify-marketplace"] { grid-area: marketplace;}
+      li[data-id$="marketplace"] { grid-area: marketplace;}
       div[data-id="/add"] { grid-area: add;}
       div[data-id="/collection/episodes"] { grid-area: episodes;}
       div[data-id="/collection/tracks"] { grid-area: tracks;}
@@ -58,7 +58,7 @@
       button, a {
         padding: 0;
 
-        div { 
+        div {
           margin-right: 0; border-radius: var(--border-radius);
 
           &.main-rootlist-statusIcons { display: none;}
@@ -98,7 +98,7 @@
       .collection-active-icon { background: url("https://i.imgur.com/CTRVDwF.png") center/cover no-repeat;}
     }
 
-    a[href="/spicetify-marketplace"] {
+    a[href$="marketplace"] {
       .collection-icon { background: url("https://i.imgur.com/2pWNa48.png") center/cover no-repeat;}
       .collection-active-icon { background: url("https://i.imgur.com/rKmXQ6V.png") center/cover no-repeat;}
     }
@@ -181,16 +181,16 @@
 
         & > div {
           contain: unset;
-        
+
           & > div:nth-child(2) {
             background-color: rgba(0, 0, 0, 0.1);
-            border-radius: 8px; 
+            border-radius: 8px;
 
             .main-rootlist-rootlistItem {
               padding: 0;
 
               .main-rootlist-rootlistItemLink {
-                padding-top: 4px; padding-bottom: 4px; 
+                padding-top: 4px; padding-bottom: 4px;
                 padding-left: calc(12px + var(--indentation)*var(--left-sidebar-item-indentation-width));
                 padding-right: var(--left-sidebar-padding-right);
                 box-sizing: content-box;
@@ -213,7 +213,7 @@
               }
             }
 
-            li:last-child::after { 
+            li:last-child::after {
               position: absolute;
               content: "";
               width: 100px; height: 40px;
@@ -228,7 +228,7 @@
   .main-coverSlotExpanded-container .cover-art .cover-art-image { border-radius: 0;}
 
   // Scrollbar
-  .os-scrollbar { 
+  .os-scrollbar {
     top: 52px; bottom: 38px;
     border-top-right-radius: calc(var(--border-radius) + 5px);
     border-bottom-right-radius: calc(var(--border-radius) + 5px);

--- a/Comfy/app.css
+++ b/Comfy/app.css
@@ -77,7 +77,6 @@
 .main-card-PlayButtonContainer {
   border-radius: var(--border-radius);
 }
-
 .ButtonInner-sc-14ud5tc-0.bxzzGk.encore-inverted-light-set {
 	border-radius: var(--border-radius);
 }
@@ -145,8 +144,7 @@
   overflow: hidden;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints {
-  -moz-column-gap: 16px;
-       column-gap: 16px;
+  column-gap: 16px;
   padding: 0 12px;
   box-sizing: content-box;
   transition: 350ms background-color;
@@ -178,7 +176,7 @@
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/new-releases"] {
   grid-area: new-releases;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id="/spicetify-marketplace"] {
+:root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list li[data-id$=marketplace] {
   grid-area: marketplace;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints#spicetify-sticky-list div[data-id="/add"] {
@@ -200,7 +198,7 @@
   background-color: transparent;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a.main-navBar-navBarLinkActive {
-  background-color: #5c6eb12a;
+  background-color: rgba(92, 110, 177, 0.1647058824);
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints > li a svg > * {
   display: none;
@@ -264,10 +262,10 @@
 :root .Root__nav-bar ul.main-navBar-entryPoints a[href="/new-releases"] .collection-active-icon {
   background: url("https://i.imgur.com/CTRVDwF.png") center/cover no-repeat;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints a[href="/spicetify-marketplace"] .collection-icon {
+:root .Root__nav-bar ul.main-navBar-entryPoints a[href$=marketplace] .collection-icon {
   background: url("https://i.imgur.com/2pWNa48.png") center/cover no-repeat;
 }
-:root .Root__nav-bar ul.main-navBar-entryPoints a[href="/spicetify-marketplace"] .collection-active-icon {
+:root .Root__nav-bar ul.main-navBar-entryPoints a[href$=marketplace] .collection-active-icon {
   background: url("https://i.imgur.com/rKmXQ6V.png") center/cover no-repeat;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div {
@@ -275,8 +273,7 @@
   grid-template-areas: "add tracks episodes" "playlists playlists playlists";
   grid-template-columns: 25px 25px 1fr;
   grid-template-rows: 25px 1fr;
-  -moz-column-gap: 16px;
-       column-gap: 16px;
+  column-gap: 16px;
   margin: 12px 12px 0 12px;
 }
 :root .Root__nav-bar ul.main-navBar-entryPoints:not(#spicetify-sticky-list) + .main-rootlist-rootlist > div > div:first-child {
@@ -363,7 +360,7 @@
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink {
   padding-top: 4px;
   padding-bottom: 4px;
-  padding-left: calc(12px + var(--indentation)*var(--left-sidebar-item-indentation-width));
+  padding-left: calc(12px + var(--indentation) * var(--left-sidebar-item-indentation-width));
   padding-right: var(--left-sidebar-padding-right);
   box-sizing: content-box;
   transition: 150ms background-color;
@@ -375,11 +372,10 @@
   margin-left: 0;
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLinkActive + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:focus + *, :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-rootlistItemLink:hover + * {
-  background-color: #5c6eb12a;
+  background-color: rgba(92, 110, 177, 0.1647058824);
 }
 :root .Root__nav-bar .main-rootlist-rootlist .os-content > ul[tabindex="0"] > div > div:nth-child(2) .main-rootlist-rootlistItem .main-rootlist-statusIcons:not(:empty) {
-  -webkit-margin-start: 0;
-          margin-inline-start: 0;
+  margin-inline-start: 0;
   padding: 4px 12px;
   transition: 150ms background-color;
 }
@@ -403,11 +399,6 @@
   bottom: 38px;
   border-top-right-radius: calc(var(--border-radius) + 5px);
   border-bottom-right-radius: calc(var(--border-radius) + 5px);
-  overflow: hidden;
-}
-
-#main{
-  background-color: var(--spice-main);
   overflow: hidden;
 }
 
@@ -570,7 +561,7 @@
   content: none;
 }
 :root #context-menu ul button:not(.main-contextMenu-disabled):focus, :root #context-menu ul button:not(.main-contextMenu-disabled):hover, :root #context-menu ul button[aria-expanded=true], :root #context-menu ul a:not(.main-contextMenu-disabled):focus, :root #context-menu ul a:not(.main-contextMenu-disabled):hover, :root #context-menu ul a[aria-expanded=true] {
-  background-color: #5c6eb12a;
+  background-color: rgba(92, 110, 177, 0.1647058824);
   transition: 150ms background-color;
 }
 :root #bookmark-menu {
@@ -587,6 +578,6 @@
   content: none;
 }
 :root #bookmark-menu button:not(.main-contextMenu-disabled):focus, :root #bookmark-menu button:not(.main-contextMenu-disabled):hover, :root #bookmark-menu button[aria-expanded=true], :root #bookmark-menu a:not(.main-contextMenu-disabled):focus, :root #bookmark-menu a:not(.main-contextMenu-disabled):hover, :root #bookmark-menu a[aria-expanded=true] {
-  background-color: #5c6eb12a;
+  background-color: rgba(92, 110, 177, 0.1647058824);
   transition: 150ms background-color;
 }

--- a/Comfy/assets/_navbar.scss
+++ b/Comfy/assets/_navbar.scss
@@ -21,7 +21,7 @@
       li[data-id="/lyrics-plus"] { grid-area: lyrics-plus;}
       li[data-id="/reddit"] { grid-area: reddit;}
       li[data-id="/new-releases"] { grid-area: new-releases;}
-      li[data-id="/spicetify-marketplace"] { grid-area: marketplace;}
+      li[data-id$="marketplace"] { grid-area: marketplace;}
       div[data-id="/add"] { grid-area: add;}
       div[data-id="/collection/episodes"] { grid-area: episodes;}
       div[data-id="/collection/tracks"] { grid-area: tracks;}
@@ -58,7 +58,7 @@
       button, a {
         padding: 0;
 
-        div { 
+        div {
           margin-right: 0; border-radius: var(--border-radius);
 
           &.main-rootlist-statusIcons { display: none;}
@@ -98,7 +98,7 @@
       .collection-active-icon { background: url("https://i.imgur.com/CTRVDwF.png") center/cover no-repeat;}
     }
 
-    a[href="/spicetify-marketplace"] {
+    a[href$="marketplace"] {
       .collection-icon { background: url("https://i.imgur.com/2pWNa48.png") center/cover no-repeat;}
       .collection-active-icon { background: url("https://i.imgur.com/rKmXQ6V.png") center/cover no-repeat;}
     }
@@ -181,16 +181,16 @@
 
         & > div {
           contain: unset;
-        
+
           & > div:nth-child(2) {
             background-color: rgba(0, 0, 0, 0.1);
-            border-radius: 8px; 
+            border-radius: 8px;
 
             .main-rootlist-rootlistItem {
               padding: 0;
 
               .main-rootlist-rootlistItemLink {
-                padding-top: 4px; padding-bottom: 4px; 
+                padding-top: 4px; padding-bottom: 4px;
                 padding-left: calc(12px + var(--indentation)*var(--left-sidebar-item-indentation-width));
                 padding-right: var(--left-sidebar-padding-right);
                 box-sizing: content-box;
@@ -213,7 +213,7 @@
               }
             }
 
-            li:last-child::after { 
+            li:last-child::after {
               position: absolute;
               content: "";
               width: 100px; height: 40px;
@@ -228,7 +228,7 @@
   .main-coverSlotExpanded-container .cover-art .cover-art-image { border-radius: 0;}
 
   // Scrollbar
-  .os-scrollbar { 
+  .os-scrollbar {
     top: 52px; bottom: 38px;
     border-top-right-radius: calc(var(--border-radius) + 5px);
     border-bottom-right-radius: calc(var(--border-radius) + 5px);


### PR DESCRIPTION
Change ruleset to add compatibility for both versions of Marketplace

Note: There are a **lot** of concerning changes on the CSS file when I compiled it from the SCSS file using `sass --watch`, most likely because the CSS file is directly changed for patches and not patched & compiled from the SCSS file. Nonetheless, I've did my best adding those rulesets back and it should be working as expected.