### PR TITLE
Add code to remove the triangle left over when listening on a separate device

### DIFF
--- a/Comfy/user.css
+++ b/Comfy/user.css
@@ -1,5 +1,8 @@
 @import url("https://comfy-themes.github.io/Spicetify/Comfy/app.css");
 
+/* Blocks the small triangle shown when listening on a separate device */
+.iUSAh1wdhXLk9hHSbkCA:after{display:none !important;}
+
 /*/ ENABLE THIS LINE FOR HOVERED PANELS
 
 .Root__nav-bar {position: absolute;width: 40px;opacity: 0;bottom: 0;left: 0;top: 0;z-index: 1;}nav.Root__nav-bar:hover {position: inherit;width: 225px;opacity: 1;transition: visibility 5s, opacity 0.5s linear;}.LayoutResizer__resize-bar {cursor: none;}.Root__top-bar {opacity: 0;transition: visibility 5s, opacity 1s linear;}.Root__top-bar:hover {transition-delay: 0.5s;opacity: 1;transition: visibility 5s, opacity 0.5s linear;}.main-topBar-container {-webkit-padding-end: 32px;padding: 16px 85px;padding-inline-end: 32px;max-width: none;}aside[aria-label='Friend Activity']:hover {position: inherit;width: var(--buddy-feed-width);opacity: 1;transition: visibility 5s, opacity 0.5s linear;left: 0;}aside[aria-label='Friend Activity'] {position: absolute;width: 65px;opacity: 0;bottom: 0;left: -30px;top: 0;z-index: 1;}


### PR DESCRIPTION
This code removed the small triangle left over when listening to Spotify on a separate device

Before: https://prnt.sc/Pl__kVcjjCw8 (has the little triangle as pointed out

After: https://prnt.sc/p4U_3iLhiS_p (the little triangle is no longer there)