### PR TITLE
fix(nowPlayingBar): overlapping duration

### DIFF
--- a/Comfy-Chromatic/app.css
+++ b/Comfy-Chromatic/app.css
@@ -449,6 +449,7 @@ justify-content: center;
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) {
 align-self: center;
+flex-shrink: 0;
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) + .main-entityHeader-headerText {
 flex: unset;
@@ -972,7 +973,6 @@ mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
 overflow: hidden;
 }
 :root #context-menu ul {
-padding: 0;
 background-color: var(--spice-player);
 }
 :root #context-menu ul button, :root #context-menu ul a {
@@ -1003,5 +1003,5 @@ background-color: #5c6eb12a;
 transition: 150ms background-color;
 }
 .iUSAh1wdhXLk9hHSbkCA:after{
-  display:none !important; /*Removes the small triangle over the play bar when playing on a sepret device*/ 
+  display:none !important; /*Removes the small triangle over the play bar when playing on a sepret device*/
 }

--- a/Comfy-Chromatic/app.scss
+++ b/Comfy-Chromatic/app.scss
@@ -17,7 +17,7 @@
     .main-trackList-rowSectionEnd .main-addButton-active, .main-trackList-rowSectionEnd .main-addButton-active:focus, .main-trackList-rowSectionEnd .main-addButton-active:hover { color: #d25050;}
 
     // Lyrics plus
-    .lyrics-lyricsContainer-LyricsBackground { 
+    .lyrics-lyricsContainer-LyricsBackground {
         background-repeat: no-repeat;
         background-size: cover;
         -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
@@ -28,7 +28,6 @@
         overflow: hidden;
 
         ul {
-            padding: 0;
             background-color: var(--spice-player);
 
             button, a {
@@ -53,5 +52,5 @@
             &:not(.main-contextMenu-disabled):focus, &:not(.main-contextMenu-disabled):hover, &[aria-expanded=true] { background-color: #5c6eb12a; transition: 150ms background-color;}
         }
     }
-	
+
 }

--- a/Comfy-Chromatic/assets/_main.scss
+++ b/Comfy-Chromatic/assets/_main.scss
@@ -48,6 +48,7 @@
 
         & > div:nth-last-of-type(2) {
             align-self: center;
+            flex-shrink: 0;
 
             & + .main-entityHeader-headerText {
                 flex: unset;

--- a/Comfy-Mono/app.css
+++ b/Comfy-Mono/app.css
@@ -399,6 +399,7 @@ margin-right: 24px
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) {
   align-self: center;
+  flex-shrink: 0;
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) + .main-entityHeader-headerText {
   flex: unset;
@@ -922,7 +923,6 @@ margin-right: 24px
   overflow: hidden;
 }
 :root #context-menu ul {
-  padding: 0;
   background-color: var(--spice-player);
 }
 :root #context-menu ul button, :root #context-menu ul a {
@@ -953,5 +953,5 @@ margin-right: 24px
   transition: 150ms background-color;
 }
 .iUSAh1wdhXLk9hHSbkCA:after{
-  display:none !important; /*Removes the small triangle over the play bar when playing on a sepret device*/ 
+  display:none !important; /*Removes the small triangle over the play bar when playing on a sepret device*/
 }

--- a/Comfy-Mono/app.scss
+++ b/Comfy-Mono/app.scss
@@ -17,7 +17,7 @@
     .main-trackList-rowSectionEnd .main-addButton-active, .main-trackList-rowSectionEnd .main-addButton-active:focus, .main-trackList-rowSectionEnd .main-addButton-active:hover { color: #d25050;}
 
     // Lyrics plus
-    .lyrics-lyricsContainer-LyricsBackground { 
+    .lyrics-lyricsContainer-LyricsBackground {
         background-repeat: no-repeat;
         background-size: cover;
         -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
@@ -28,7 +28,6 @@
         overflow: hidden;
 
         ul {
-            padding: 0;
             background-color: var(--spice-player);
 
             button, a {
@@ -53,5 +52,5 @@
             &:not(.main-contextMenu-disabled):focus, &:not(.main-contextMenu-disabled):hover, &[aria-expanded=true] { background-color: #5c6eb12a; transition: 150ms background-color;}
         }
     }
-	
+
 }

--- a/Comfy-Mono/assets/_main.scss
+++ b/Comfy-Mono/assets/_main.scss
@@ -48,6 +48,7 @@
 
         & > div:nth-last-of-type(2) {
             align-self: center;
+            flex-shrink: 0;
 
             & + .main-entityHeader-headerText {
                 flex: unset;

--- a/Comfy/app.css
+++ b/Comfy/app.css
@@ -52,6 +52,7 @@
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) {
   align-self: center;
+  flex-shrink: 0;
 }
 :root .Root__main-view .main-entityHeader-container > div:nth-last-of-type(2) + .main-entityHeader-headerText {
   flex: unset;
@@ -560,7 +561,6 @@
   overflow: hidden;
 }
 :root #context-menu ul {
-  padding: 0;
   background-color: var(--spice-player);
 }
 :root #context-menu ul button, :root #context-menu ul a {
@@ -591,5 +591,5 @@
   transition: 150ms background-color;
 }
 .iUSAh1wdhXLk9hHSbkCA:after{
-  display:none !important; /*Removes the small triangle over the play bar when playing on a sepret device*/ 
+  display:none !important; /*Removes the small triangle over the play bar when playing on a sepret device*/
 }

--- a/Comfy/app.css
+++ b/Comfy/app.css
@@ -406,12 +406,16 @@
   border-bottom-right-radius: calc(var(--border-radius) + 5px);
   overflow: hidden;
 }
-
 #main{
   background-color: var(--spice-main);
   overflow: hidden;
 }
-
+:root .Root__now-playing-bar .OCY4jHBlCVZEyGvtSv0J {
+  height: 110px;
+}
+:root .Root__now-playing-bar [class^=main-nowPlayingBar-] {
+  padding-bottom: 30px;
+}
 :root .Root__now-playing-bar .main-nowPlayingBar-container {
   position: relative;
   border-top: none;
@@ -424,10 +428,13 @@
 :root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying.main-nowPlayingWidget-coverExpanded {
   transform: translateX(-100px);
 }
-:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying .main-coverSlotCollapsed-container {
+:root .Root__now-playing-bar .main-nowPlayingBar-left .qWcH8e2laY9sYOuCsOAx {
+  top: -15px;
+}
+:root .Root__now-playing-bar .main-nowPlayingBar-left .BFR9Zt3zpL8BATBMiwQB {
   top: -20px;
 }
-:root .Root__now-playing-bar .main-nowPlayingBar-container .main-nowPlayingBar-nowPlayingBar .main-nowPlayingWidget-nowPlaying .main-coverSlotCollapsed-container .cover-art {
+:root .Root__now-playing-bar .main-nowPlayingBar-left a:not([tabindex="-1"]) > .BFR9Zt3zpL8BATBMiwQB .cover-art {
   width: 84px !important;
   height: 84px !important;
   border-radius: var(--border-radius);

--- a/Comfy/app.scss
+++ b/Comfy/app.scss
@@ -16,7 +16,7 @@
     .main-trackList-rowSectionEnd .main-addButton-active, .main-trackList-rowSectionEnd .main-addButton-active:focus, .main-trackList-rowSectionEnd .main-addButton-active:hover { color: #d25050;}
 
     // Lyrics plus
-    .lyrics-lyricsContainer-LyricsBackground { 
+    .lyrics-lyricsContainer-LyricsBackground {
         background-repeat: no-repeat;
         background-size: cover;
         -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6));
@@ -27,7 +27,6 @@
         overflow: hidden;
 
         ul {
-            padding: 0;
             background-color: var(--spice-player);
 
             button, a {

--- a/Comfy/assets/_main.scss
+++ b/Comfy/assets/_main.scss
@@ -48,6 +48,7 @@
 
         & > div:nth-last-of-type(2) {
             align-self: center;
+            flex-shrink: 0;
 
             & + .main-entityHeader-headerText {
                 flex: unset;


### PR DESCRIPTION
Fixes overlapping duration in latest versions of Spotify
Also brings back larger album image like in preview
![Rzu4m1fN6J](https://user-images.githubusercontent.com/77577746/172766405-54c2c67d-324f-4c3e-8295-a7a2e08095ef.gif)
Have only tested and patched on original Comfy.
