### PR TITLE
Update comfy.scripts.js link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ spicetify apply
 
 The theme automatically updates for users using the version of Spicetify equals or greater than `2.8.2`, however, for the users that don't want to update Spicetify to the newest version:
 
-1. Go [here](https://comfy-themes.github.io/Spicetify/Comfy/Comfy.script.js)
+1. Go [here](https://comfy-themes.github.io/Spicetify/Comfy/comfy.script.js)
 2. Copy the whole code (sorry for the flashbang)
 3. Go into the Spicetify extension folder
 4. Open the `comfy.js` file, paste the code and **save it**


### PR DESCRIPTION
The [link to comfy.scripts.js](https://github.com/Comfy-Themes/Spicetify/blob/0fa5b373a18c7fa8d2541f13558ed60b202d254d/README.md?plain=1#L66) is currently broken and doesn't link to the actual raw JS data, updated link redirects to the correct resource :)