### PR TITLE
Remove "Remove playback timers" from default css

### DIFF
--- a/Comfy/app.css
+++ b/Comfy/app.css
@@ -506,12 +506,6 @@
 :root .Root__now-playing-bar .playback-bar .saber-hilt {
   height: 0;
 }
-:root .Root__now-playing-bar .playback-bar .playback-bar__progress-time-elapsed {
-  display: none;
-}
-:root .Root__now-playing-bar .playback-bar .main-playbackBarRemainingTime-container {
-  display: none;
-}
 :root .Root__now-playing-bar .playback-bar .playback-progressbar {
   grid-column: 1/3;
   grid-area: bar;


### PR DESCRIPTION
This is the change I was attempting to make before subsequently slightly messing up comfys commit history.