### PR TITLE
Simplify Linux install script and fixed issues regarding bash/sh inco…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,14 +2,9 @@
 
 set -e
 
-function dots {
-    while true; do
-        printf "."
-        sleep 0.1
-    done
-}
+# Download URL
+theme_url="https://raw.githubusercontent.com/Comfy-Themes/Spicetify/main/Comfy"
 
-echo "Downloading"
 # Setup directories to download to
 spice_dir="$(dirname "$(spicetify -c)")"
 theme_dir="${spice_dir}/Themes"
@@ -19,30 +14,12 @@ ext_dir="${spice_dir}/Extensions"
 mkdir -p "${theme_dir}/Comfy"
 mkdir -p "${ext_dir}"
 
-# Download latest tagged files into correct directories
-theme_url="https://raw.githubusercontent.com/Comfy-Themes/Spicetify/main/Comfy"
-
-# Call dots function in background
-dots &
-dots_pid=$!
-# Avoid kill message for dots
-disown
-
-# Store PIDs of curls to kill later
-pids=()
-curl --silent --output "${theme_dir}/Comfy/color.ini" "${theme_url}/color.ini" &
-pids+=($!)
-curl --silent --output "${theme_dir}/Comfy/user.css" "${theme_url}/user.css" &
-pids+=($!)
-curl --silent --output "${ext_dir}/comfy.js" "${theme_url}/comfy.js" &
-pids+=($!)
-
-# Wait for all curls to finish and kill dots
-for pid in "${pids[@]}"; do
-    wait $pid
-done
-kill $dots_pid
-echo " Done"
+# Download latest tagged files into correct director
+echo "Downloading Comfy..."
+curl --silent --output "${theme_dir}/Comfy/color.ini" "${theme_url}/color.ini"
+curl --silent --output "${theme_dir}/Comfy/user.css" "${theme_url}/user.css"
+curl --silent --output "${ext_dir}/comfy.js" "${theme_url}/comfy.js"
+echo "Done"
 
 # Apply theme
 echo "Applying theme"


### PR DESCRIPTION
The current installation script for Linux (install.sh) does not work at all.
The main reasons are incompatibilities between **bash** and **sh**.

Keywords used in the script like *function* or *disown* aren't available in pure sh and are a bash feature.

I took the radical approach and simplified the whole script while making it sh conform. Especially because I think that the fancy dots in the terminal and parallel running curls are not needed at all, because the scripts which are downloaded are so small that the installation is finished in a second anyways.

Please fix the script yourself if you think theses changes are too much. Right now I have to use my fork for my automatic install scripts and I would rather use the official main branch.

This is what the script now output when ran:

-> ./install.sh
Downloading Comfy...
Done
Applying theme
success Config changed: current_theme = Comfy
info Run "spicetify apply" to apply new config
success Config changed: color_scheme = Comfy
info Run "spicetify apply" to apply new config
warning Config "extensions" unchanged: comfy.js is already in the list.
success Config changed: inject_css = 1
info Run "spicetify apply" to apply new config
success Config changed: replace_colors = 1
info Run "spicetify apply" to apply new config
success Config changed: overwrite_assets = 1
info Run "spicetify apply" to apply new config
spicetify v2.16.2
Overwriting themed assets:
OK
Transferring user.css:
OK
Applying additional modifications:
OK
Transferring extensions:
OK
Transferring custom apps:
OK
success Spotify is spiced up!
All done!