### PR TITLE
style: mono background gradient change

### DIFF
--- a/Comfy/snippets/mono.css
+++ b/Comfy/snippets/mono.css
@@ -18,3 +18,8 @@
 svg.main-coverSlotExpandedCollapseButton-chevron {
     color: rgb(0,0,0);
 }
+
+:root .Root__main-view .artist-artistOverview-artistOverviewContent,
+:root .Root__main-view .main-actionBarBackground-background {
+ 	background: linear-gradient(rgba(var(--spice-rgb-main), 0.6) 0, var(--spice-main) 232px), var(--background-noise) !important;
+}


### PR DESCRIPTION
Changed playlist and artist background gradient in mono snippet file. Now it is using the `--spice-rgb-main` color instead of `--spice-rgb-main-transition`. I think this fits in better with the aesthetics of the theme.

Before:
![image](https://user-images.githubusercontent.com/37307597/227898881-fa382b76-47af-4c24-b5bf-35e434385a5d.png)

After:
![Screenshot_1](https://user-images.githubusercontent.com/37307597/227898927-739b518a-6276-47e6-a8df-4ce97a445b96.png)
