### PR TITLE
Fix odd spacing

### DIFF
--- a/Comfy/app.scss
+++ b/Comfy/app.scss
@@ -65,7 +65,7 @@
 	}
 
 	.global-nav .Root__top-container {
-		grid-template-rows: calc(var(--comfy-topbar-height, 64px) / var(--zoom, 1) - 16px) 1fr auto;
+		grid-template-rows: calc(var(--comfy-topbar-height, 64px) / var(--zoom, 1) - 16px) 0px 1fr;
 	}
 
 	&.spotify__container--is-desktop.spotify__os--is-windows:not(.fullscreen) {


### PR DESCRIPTION
Resolves #240

This fix works for me, but honestly I'm not entirely sure why it was like this to begin with—I guess Spotify has added another row to the grid. 

Before:
<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/5bf6c710-e7cf-4a03-9393-59eb5bf2b3c3" />

After:
<img width="1917" height="1000" alt="image" src="https://github.com/user-attachments/assets/8288184d-c2e1-449a-bffa-33f8b3a7f952" />

Also works fine with non-maximised windows and such.
