### PR TITLE
add colorscheme: Gruvbox Dark Hard

### DIFF
--- a/Comfy/color.ini
+++ b/Comfy/color.ini
@@ -54,6 +54,34 @@ heart              = 1DB954
 pagelink-active    = 333333
 radio-btn-active   = 1DB954
 
+[Gruvbox-dark-hard]
+text               = EBDBB2  ; fg (bright)
+subtext            = D5C4A1  ; fg1 (dim)
+main               = 1B1D1B  ; bg0_h (very dark)
+main-elevated      = 242424  ; bg0   (slightly lighter)
+main-transition    = EBDBB2  ; fg (bright)
+highlight          = 32302F  ; bg1   (dark but not black)
+highlight-elevated = 45403D  ; bg2   (extra subtle depth)
+sidebar            = 151515  ; custom very dark sidebar
+player             = 1B1D1B  ; bg0_h
+card               = 32302F  ; bg1
+shadow             = 7C6F64  ; gray (shadow inflection)
+selected-row       = FBF1C7  ; fg_light (bright accent)
+button             = EBDBB2  ; fg
+button-active      = D5C4A1  ; fg1
+button-disabled    = 665C54  ; gray-dark
+tab-active         = 45403D  ; bg2
+notification       = 1B1D1B  ; bg0_h
+notification-error = CC241D  ; red (error)
+misc               = 000000  ; pure black
+play-button        = EBDBB2  ; fg
+play-button-active = FBF1C7  ; fg_light
+progress-fg        = FABD2F  ; yellow (accent)
+progress-bg        = 32302F  ; bg1
+heart              = FB4934  ; red-light
+pagelink-active    = B8BB26  ; green (accent)
+radio-btn-active   = 83A598  ; blue-grey accent
+
 [Nord]
 text               = B2BCCC
 subtext            = B2BCCC


### PR DESCRIPTION
Added gruvbox dark hard colorscheme to comfy theme

Credits: https://github.com/morhetz/gruvbox