### PR TITLE
fix: account for the top-banner row in .Root__top-container

### DIFF
--- a/Comfy/app.scss
+++ b/Comfy/app.scss
@@ -65,7 +65,7 @@
 	}
 	
 	.global-nav .Root__top-container {
-		grid-template-rows: max(48px, calc(var(--comfy-topbar-height, 64px) / var(--zoom, 1) - 16px)) minmax(0, 1fr) auto;
+		grid-template-rows: auto max(48px, calc(var(--comfy-topbar-height, 64px) / var(--zoom, 1) - 16px)) minmax(0, 1fr) auto;
 	}
 
 	&.spotify__container--is-desktop.spotify__os--is-windows:not(.fullscreen) {


### PR DESCRIPTION
Fixes the broken layout reported in #252 (and, I believe, #248 / #247 / #256 / #258, which all look like the same thing).

### The bug

`.Root__top-container` has **four** rows on current Spotify — a `top-banner` row was added above `global-nav`:

```css
.Root__top-container {
  grid-template:
    "top-banner       top-banner       top-banner"
    "global-nav       global-nav       global-nav"
    "left-sidebar     main-view        right-sidebar" 1fr
    "now-playing-bar  now-playing-bar  now-playing-bar"
    / auto 1fr;
}
```

`Comfy/app.scss:68` supplies **three** track sizes, so each one is seated a row too high:

| row | intended | actually gets |
|---|---|---|
| `top-banner` | — | `max(48px, …)` |
| `global-nav` | `max(48px, …)` | `minmax(0, 1fr)` |
| `left-sidebar / main-view / right-sidebar` | `minmax(0, 1fr)` | `auto` |
| `now-playing-bar` | `auto` | `auto` (implicit) |

The empty `global-nav` row swallows the `1fr` — the large blank gap people are reporting — and the content row drops to `auto`, collapsing to content height and then getting clipped by `:root .Root__top-container { overflow: hidden }`. The left sidebar, main view and right panel all end up squashed into a short band at the bottom of the window.

### The change

Adds the missing leading `auto` track so the sizes line up with the rows they were written for. `auto` collapses `top-banner` to 0 when there's no banner and still gives it room when Spotify renders one.

Only `app.scss` is touched — `app.css` is left for the Build workflow to regenerate, matching #250.

### Verified

Spotify `1.2.95.453.g0eeebbed`, Spicetify `2.44.0`, Linux. Measured over CDP against the running client: computed `grid-template-rows` goes to `0px 54.09px 954.65px 83.99px`, and `.Root__main-view` returns to `top: 78, height: 955` in a 1132px viewport instead of a short strip at the bottom.

### Two things worth a maintainer's judgement

1. **This is the line #250 changed.** The pre-#250 value (`calc(…) 0px 1fr`) also had three tracks, but they happened to seat correctly against the four-row grid — which is why the workaround being passed around in #252 is literally the old value. #250 reordered them for a three-row container, and that's where this regressed.

2. **I could only verify against 1.2.95.** If `main` is still expected to support clients whose `.Root__top-container` has no `top-banner` row, this patch would mis-seat the tracks for *them* instead, and something version-agnostic would be safer. Worth noting that `beta` drops this override entirely and reportedly works on current Spotify — if the override no longer earns its keep on `main` either, removing it may be the better fix than patching the track count. Happy to redo it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
